### PR TITLE
[feat] DB 인프라 세팅

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -50,14 +50,14 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+ .idea/artifacts
+ .idea/compiler.xml
+ .idea/jarRepositories.xml
+ .idea/modules.xml
+ .idea/*.iml
+ .idea/modules
+ *.iml
+ *.ipr
 
 # CMake
 cmake-build-*/
@@ -242,3 +242,7 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/git,intellij,java,gradle,macos,windows
+
+# security 정보
+application-oauth.yml
+application-jwt.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,12 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Jasypt(Encrypt)
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3'
+
+	// Query logging
+	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/sullog/backend/common/config/JasyptConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/JasyptConfig.java
@@ -1,0 +1,31 @@
+package sullog.backend.common.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JasyptConfig {
+
+    @Value("${JASYPT_PASSWORD}")
+    String password;
+
+    @Bean(name = "jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+//        System.out.println("password = " + password);
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(password); // 암호화할 때 사용하는 키
+        config.setAlgorithm("PBEWithMD5AndDES"); // 암호화 알고리즘
+        config.setKeyObtentionIterations("1000"); // 반복할 해싱 회수
+        config.setPoolSize("1"); // 인스턴스 pool
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator"); // salt 생성 클래스
+        config.setStringOutputType("base64"); //인코딩 방식
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/backend/src/main/java/sullog/backend/common/config/MybatisConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/MybatisConfig.java
@@ -1,0 +1,41 @@
+package sullog.backend.common.config;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import javax.sql.DataSource;
+
+@Configuration
+@MapperScan(value = "sullog.backend", sqlSessionFactoryRef = "factory")
+public class MybatisConfig {
+
+    @Bean(name = "datasource")
+    @ConfigurationProperties(prefix = "spring.datasource")
+    public DataSource dataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "factory")
+    public SqlSessionFactory sqlSessionFactory(@Qualifier("datasource") DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean sqlSessionFactory = new SqlSessionFactoryBean();
+        sqlSessionFactory.setDataSource(dataSource);
+        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+        sqlSessionFactory.setMapperLocations(resolver.getResources("classpath:/mapper/**/*.xml"));
+
+        return sqlSessionFactory.getObject();
+    }
+
+    @Bean(name = "sqlSession")
+    public SqlSessionTemplate sqlSession(SqlSessionFactory sqlSessionFactory) {
+        return new SqlSessionTemplate(sqlSessionFactory);
+    }
+}
+

--- a/backend/src/main/resources/application-alpha.yml
+++ b/backend/src/main/resources/application-alpha.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+    jdbc-url: ENC(IILZOkyZ39yX4NAP9z9HEdTxL4iLSEN7e9pzJyGeVDlKH4g1FChj614Jx8Drt+36/MenMOhS3ZLIDe4le1kLzmuscvCeJIxEvB2iVQD05EBOZRrKgNMCLRxGXpnu6lQ9zjd0KALwZ380fD3dyxRPw4T+rN402GVtECh0WWmfPU8wCjgmXXZlgQPU3mtCS+Xs+g/C+zMIDuP4QN8OWf2dwjbxYEth3f+PSj2KPe33a23vz2xbxze+Y5Ufbbzm79KY)
+    username: ENC(aNexS6IkSpTXHGWZeqlYIi3mH3QEFohI)
+    password: ENC(YRlxk0mURqreyy0hCKf9L1eXJrvPXwjO)
+    hikari: # Connection Pool 설정 (Hikari CP가 해당 역할 수행)
+      #        maximum-pool-size: 10
+      #        connection-timeout: 5000
+      #        connection-init-sql: SELECT 1
+      #        validation-timeout: 2000
+      #        minimum-idle: 10
+      #        idle-timeout: 600000
+      #        max-lifetime: 1800000
+      max-lifetime: 6000 # Possibly consider using a shorter maxLifetime value.(10000 => 6000)
+mybatis:
+  mapper-locations: "classpath:/mapper/**/*.xml"
+logging:
+  level:
+    jdbc:
+      sqlonly: info
+      sqltiming: info
+      resultsettable: off
+      audit: off
+      resultset: off
+      connection: off

--- a/backend/src/main/resources/application-live.yml
+++ b/backend/src/main/resources/application-live.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+    jdbc-url: ENC(zjBtV0qTQtTCiy0BNxPu9EF6opEy4qNGcZ6VLr+RsLKZcEjpOEavZmiaknnTSW4Q/CI+73aLUwMD/E9nB6MPvoUp/xsbNhCJnRS/KZ4E4lAjbr2DU4rZasd94BDs3wJq9in17z8tGhqI/xlU+khJ+zf0dYzKWlooAM7wFGiUjSeQg37uYlnWEi0qVheziIyPDtpvQusalyWt1wb3caKE3vrd0lQwDvOV27PAFiv5iSvdqHdHpKFKooTdAuaOl2lX)
+    username: ENC(aNexS6IkSpTXHGWZeqlYIi3mH3QEFohI)
+    password: ENC(YRlxk0mURqreyy0hCKf9L1eXJrvPXwjO)
+    hikari: # Connection Pool 설정 (Hikari CP가 해당 역할 수행)
+      #        maximum-pool-size: 10
+      #        connection-timeout: 5000
+      #        connection-init-sql: SELECT 1
+      #        validation-timeout: 2000
+      #        minimum-idle: 10
+      #        idle-timeout: 600000
+      #        max-lifetime: 1800000
+      max-lifetime: 6000 # Possibly consider using a shorter maxLifetime value.(10000 => 6000)
+
+mybatis:
+  mapper-locations: "classpath:/mapper/**/*.xml"
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,1 +1,10 @@
+spring:
+  datasource:
+    hikari:
+      max-lifetime: 600
+#      connection-timeout: 1000
+  profiles:
+    active: alpha   # alpha, live
+server:
+  port: 8877
 

--- a/backend/src/main/resources/log4jdbc.log4j2.properties
+++ b/backend/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0


### PR DESCRIPTION
## 개요
- DB 관련 인프라 세팅 완료

## 작업사항
- AWS RDS(MySQL) 적용
- MybatisConfig 설정으로 Mapper 스캔하는 basePackage 위치 및 xml 위치 스캔 위치 잡음
- 쿼리 로그를 볼 수 있도록 하기 위해 log4j2 디펜던시 추가 및 log level 설정(application.yml에 있음)
- 쿼리 출력될 때 한 줄로 출력되지 않고 줄바꿈되어 깔끔하게 출력될 수 있도록 log4jdbc.properties 파일 추가
- jdbc url, id, password 정보 암호화를 위해 Jasypt 라이브러리 사용
- alpha, live로 스키마 및 기타 인프라 설정 분리할 수 있도록 application.yml 파일 세분화

## 변경로직
- application.yml을 root로 application-alpha.yml, application-live.yml 파일을 추가해 알파, 라이브 버전을 따로 관리할 수 있도록 수정

## 기타사항
- Jasypt 복호화용 암호는 개인적으로 문의해주세요.
- MySQL워크벤치 등 툴로 DB 조회 및 관리하고 싶으시면 host, pw 정보 개인적으로 문의 부탁드립니다.
- 쿼리 로그를 여러줄로 깔끔하게 출력하는 설정의 경우, 레퍼런스를 참고하다보니 log4jdbc.properties 파일을 따로 만들어 설정값을 넣어주었는데 이 설정을 application.yml에 통합시킬 수 있는 방법이 만약에 있다면 알려주시기 바랍니다.
