### PR TITLE
[feat] 전통주 경험 저장 api 개발

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// S3 upload
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -37,3 +37,13 @@ include::{snippets}/token-refresh/http-request.adoc[]
 ===== Response
 include::{snippets}/token-refresh/http-response.adoc[]
 include::{snippets}/token-refresh/response-headers.adoc[]
+
+== 3. 전통주 경험
+==== 전통주 경험 저장
+===== Request
+include::{snippets}/save-record/http-request.adoc[]
+include::{snippets}/save-record/request-parts.adoc[]
+include::{snippets}/save-record/request-part-recordInfo-fields.adoc[]
+
+===== Response
+include::{snippets}/save-record/http-response.adoc[]

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -1,0 +1,34 @@
+package sullog.backend.record.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import sullog.backend.record.dto.RecordSaveRequestDto;
+import sullog.backend.record.service.ImageUploadService;
+import sullog.backend.record.service.RecordService;
+
+import java.util.List;
+
+@RestController
+public class RecordController {
+
+    private final RecordService recordService;
+    private final ImageUploadService imageUploadService;
+
+    public RecordController(RecordService recordService, ImageUploadService imageUploadService) {
+        this.recordService = recordService;
+        this.imageUploadService = imageUploadService;
+    }
+
+    @PostMapping("/records")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void saveRecord(
+                        @RequestPart(required = false) List<MultipartFile> photoList,
+                        @RequestPart("recordInfo") RecordSaveRequestDto requestDto) {
+        // 이미지 저장
+        List<String> photoPathList = imageUploadService.uploadImageList(photoList);
+
+        // 경험기록 저장
+        recordService.saveRecord(requestDto.toEntity(photoPathList));
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/dto/RecordSaveRequestDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/RecordSaveRequestDto.java
@@ -1,0 +1,92 @@
+package sullog.backend.record.dto;
+
+import lombok.Builder;
+import sullog.backend.record.entity.AlcoholIntensity;
+import sullog.backend.record.entity.FlavorDetail;
+import sullog.backend.record.entity.Record;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public class RecordSaveRequestDto {
+
+    private Long memberId; // 작성자 id
+
+    private Long alcoholId; // 술 id
+
+    private String title; // 제목
+
+    private AlcoholIntensity alcoholIntensity; // 도수 느낌
+    private List<FlavorDetail> flavorTagList; // 상세 플레이버 태그
+    private Integer tasteScore; // 맛점수 (1~5)
+    private Integer textureScore; // 감촉점수 (1~5)
+    private String description; // 상세 내용
+    private LocalDate experienceDate; // 경험 날짜
+
+    public RecordSaveRequestDto() {
+    }
+
+    public RecordSaveRequestDto(Long memberId, Long alcoholId, String title, AlcoholIntensity alcoholIntensity, List<FlavorDetail> flavorTagList, Integer tasteScore, Integer textureScore, String description, LocalDate experienceDate) {
+        this.memberId = memberId;
+        this.alcoholId = alcoholId;
+        this.title = title;
+        this.alcoholIntensity = alcoholIntensity;
+        this.flavorTagList = flavorTagList;
+        this.tasteScore = tasteScore;
+        this.textureScore = textureScore;
+        this.description = description;
+        this.experienceDate = experienceDate;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getAlcoholId() {
+        return alcoholId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public AlcoholIntensity getAlcoholIntensity() {
+        return alcoholIntensity;
+    }
+
+    public List<FlavorDetail> getFlavorTagList() {
+        return flavorTagList;
+    }
+
+    public Integer getTasteScore() {
+        return tasteScore;
+    }
+
+    public Integer getTextureScore() {
+        return textureScore;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LocalDate getExperienceDate() {
+        return experienceDate;
+    }
+
+    public Record toEntity(List<String> photoPathList) {
+        return Record.builder()
+                .memberId(memberId)
+                .alcoholId(alcoholId)
+                .title(title)
+                .photoPathList(photoPathList)
+                .alcoholIntensity(alcoholIntensity)
+                .flavorTagList(flavorTagList)
+                .tasteScore(tasteScore)
+                .textureScore(textureScore)
+                .description(description)
+                .experienceDate(experienceDate)
+                .build();
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/entity/AlcoholIntensity.java
+++ b/backend/src/main/java/sullog/backend/record/entity/AlcoholIntensity.java
@@ -1,0 +1,7 @@
+package sullog.backend.record.entity;
+
+public enum AlcoholIntensity {
+    MILD, //연함
+    MODERATE, //보통
+    STRONG // 강함
+}

--- a/backend/src/main/java/sullog/backend/record/entity/FlavorDetail.java
+++ b/backend/src/main/java/sullog/backend/record/entity/FlavorDetail.java
@@ -1,0 +1,45 @@
+package sullog.backend.record.entity;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FlavorDetail {
+    private FlavorTag majorTag;
+    private String detailTag;
+
+    public FlavorDetail() {
+    }
+
+    private FlavorDetail(FlavorTag majorTag, String detailTag) {
+        this.majorTag = majorTag;
+        this.detailTag = detailTag;
+    }
+
+    public static FlavorDetail of(String majorTag, String detailTag) {
+        return new FlavorDetail(FlavorTag.valueOf(majorTag), detailTag);
+    }
+
+    public FlavorTag getMajorTag() {
+        return majorTag;
+    }
+
+    public String getDetailTag() {
+        return detailTag;
+    }
+
+    enum FlavorTag {
+
+        FLOWER(Arrays.asList("CHRYSANTHEMUM", "PLUM_BLOSSOM", "ACACIA", "LOTUS", "ROSE")),
+        FRUIT(Arrays.asList("CITRUS", "STRAWBERRY", "JAPANESE_PLUM", "MELON", "BANANA", "PEAR", "PEACH", "APPLE", "WILD_STRAWBERRY", "APRICOT", "YUZU", "PLUM", "CANTALOUPE", "PINEAPPLE")),
+        GRAIN(Arrays.asList("POTATO", "FRESHLY_COOKED_RICE", "SWEET_POTATO", "GRAIN_POWDER", "NURUNGJI", "WHEAT", "RAW_RICE", "CORN")),
+        NUT(Arrays.asList("PEANUT", "CHESTNUT", "ALMOND", "PINE_NUT")),
+        SWEETENER(Arrays.asList("HONEY", "MALT_SYRUP", "BROWN_RICE_SYRUP", "CARAMEL")),
+        DAIRY(Arrays.asList("BUTTER", "YOGURT", "MILK", "CHEESE"));
+
+        private List<String> detailTagList;
+
+        FlavorTag(List<String> detailTagList) {
+            this.detailTagList = detailTagList;
+        }
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/entity/Record.java
+++ b/backend/src/main/java/sullog/backend/record/entity/Record.java
@@ -1,0 +1,29 @@
+package sullog.backend.record.entity;
+
+import lombok.Builder;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public class Record {
+
+    private Long memberId;
+    private Long alcoholId;
+
+    private Long recordId; //auto increment
+    private String title; // 제목
+    private List<String> photoPathList; // 사진 경로(3장까지)
+    private AlcoholIntensity alcoholIntensity; // 도수 느낌
+    private List<FlavorDetail> flavorTagList; // 상세 플레이버 태그
+    private Integer tasteScore; // 맛점수 (1~5)
+    private Integer textureScore; // 감촉점수 (1~5)
+    private String description; // 상세 내용
+    private LocalDate experienceDate; // 경험 날짜
+
+    //TODO baseEntity로 분리
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Instant deletedAt;
+}

--- a/backend/src/main/java/sullog/backend/record/error/exception/ImageUploadException.java
+++ b/backend/src/main/java/sullog/backend/record/error/exception/ImageUploadException.java
@@ -1,0 +1,10 @@
+package sullog.backend.record.error.exception;
+
+public class ImageUploadException extends RuntimeException {
+
+    //    TODO private ErrorCode errorCode;
+    public ImageUploadException(String message) {
+        super(message); // TODO: 나중에 code로 옮기기
+    }
+
+}

--- a/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
@@ -1,0 +1,10 @@
+package sullog.backend.record.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import sullog.backend.record.entity.Record;
+
+@Mapper
+public interface RecordMapper {
+
+    void insertRecord(Record record);
+}

--- a/backend/src/main/java/sullog/backend/record/mapper/typeHandler/AlcoholIntensityTypeHandler.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/typeHandler/AlcoholIntensityTypeHandler.java
@@ -1,0 +1,12 @@
+package sullog.backend.record.mapper.typeHandler;
+
+import org.apache.ibatis.type.EnumTypeHandler;
+import sullog.backend.record.entity.AlcoholIntensity;
+
+
+public class AlcoholIntensityTypeHandler extends EnumTypeHandler<AlcoholIntensity> {
+
+    public AlcoholIntensityTypeHandler(Class type) {
+        super(type);
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/mapper/typeHandler/FlavorTagListTypeHandler.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/typeHandler/FlavorTagListTypeHandler.java
@@ -1,0 +1,51 @@
+package sullog.backend.record.mapper.typeHandler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import sullog.backend.record.entity.FlavorDetail;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class FlavorTagListTypeHandler extends BaseTypeHandler<List<FlavorDetail>> {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, List<FlavorDetail> parameter, JdbcType jdbcType) throws SQLException {
+        try {
+            ps.setString(i, objectMapper.writeValueAsString(parameter));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<FlavorDetail> getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return jsonToFlavorTagMap(rs.getString(columnName));
+    }
+
+    @Override
+    public List<FlavorDetail> getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return jsonToFlavorTagMap(rs.getString(columnIndex));
+    }
+
+    @Override
+    public List<FlavorDetail> getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return jsonToFlavorTagMap(cs.getString(columnIndex));
+    }
+
+    private List<FlavorDetail> jsonToFlavorTagMap(String jsonString) {
+        try {
+            return objectMapper.readValue(jsonString, new TypeReference<List<FlavorDetail>>() {});
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/service/ImageUploadService.java
+++ b/backend/src/main/java/sullog/backend/record/service/ImageUploadService.java
@@ -1,0 +1,79 @@
+package sullog.backend.record.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import sullog.backend.record.error.exception.ImageUploadException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+public class ImageUploadService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public ImageUploadService(AmazonS3Client amazonS3Client) {
+        this.amazonS3Client = amazonS3Client;
+    }
+
+    public List<String> uploadImageList(List<MultipartFile> multipartFileList) {
+        if(multipartFileList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> pathList = new ArrayList<>();
+        for (MultipartFile multipartFile: multipartFileList) {
+            pathList.add(uploadToS3(multipartFile));
+        }
+
+        return pathList;
+    }
+
+    private String uploadToS3(MultipartFile multipartFile) {
+        String fileName = multipartFile.getOriginalFilename();
+
+        //파일 형식 구하기
+        String contentType = getFileContentType(fileName);
+
+        //S3 서버에 업로드
+        uploadS3(multipartFile, fileName, contentType);
+
+        // 경로 리턴
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void uploadS3(MultipartFile multipartFile, String fileName, String contentType) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(contentType);
+
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (Exception e) {
+            log.error("S3에 업로드 중 예외 발생", e);
+            throw new ImageUploadException("S3에 업로드 중 예외 발생"); // TODO common error 정의해서 던지기
+        }
+    }
+
+    private String getFileContentType(String fileName) {
+        String ext = fileName.split("\\.")[1];
+
+        switch (ext) {
+            case "jpeg":
+                return "image/jpeg";
+            case "png":
+                return "image/png";
+            default:
+                throw new ImageUploadException("올바른 이미지가 아닙니다."); // TODO common error로 정의해서 처리
+        }
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/service/RecordService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordService.java
@@ -1,0 +1,19 @@
+package sullog.backend.record.service;
+
+import org.springframework.stereotype.Service;
+import sullog.backend.record.entity.Record;
+import sullog.backend.record.mapper.RecordMapper;
+
+@Service
+public class RecordService {
+
+    private final RecordMapper recordMapper;
+
+    public RecordService(RecordMapper recordMapper) {
+        this.recordMapper = recordMapper;
+    }
+
+    public void saveRecord(Record record) {
+        recordMapper.insertRecord(record);
+    }
+}

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="sullog.backend.record.mapper.RecordMapper">
+
+    <insert id="insertRecord">
+        INSERT INTO sullog_alpha.record
+        (
+            member_id,
+            alcohol_id,
+            title,
+            photo_path,
+            alcohol_intensity,
+            flavor_tag_list,
+            taste_score,
+            texture_score,
+            description,
+        )
+        VALUES (
+                   #{record.memberId},
+                   #{record.alcoholId},
+                   #{record.title},
+                   #{record.photo_path},
+                   #{record.alcoholIntensity, typeHandler=sullog.backend.record.mapper.typeHandler.AlcoholIntensityTypeHandler},
+                   #{record.flavor_tag_list, typeHander=sullog.backend.record.mapper.typeHandler.FlavorTagListTypeHandler},
+                   #{record.taste_score},
+                   #{record.texture_score},
+                   #{record.description}
+               );
+    </insert>
+
+
+</mapper>

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -1,0 +1,120 @@
+package sullog.backend.record.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import sullog.backend.member.config.jwt.JwtAuthFilter;
+import sullog.backend.member.service.TokenService;
+import sullog.backend.record.entity.FlavorDetail;
+import sullog.backend.record.dto.RecordSaveRequestDto;
+import sullog.backend.record.entity.AlcoholIntensity;
+import sullog.backend.record.entity.Record;
+import sullog.backend.record.service.ImageUploadService;
+import sullog.backend.record.service.RecordService;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RecordController.class)
+@ExtendWith(RestDocumentationExtension.class)
+class RecordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RecordService recordService;
+
+    @MockBean
+    private ImageUploadService imageUploadService;
+
+    @MockBean
+    private JwtAuthFilter jwtAuthFilter;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setUp(WebApplicationContext webApplicationContext,
+                      RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .build();
+    }
+
+    @Test
+    public void saveRecordTest() throws Exception {
+        // given
+        List<FlavorDetail> flavorDetailList = Arrays.asList(FlavorDetail.of("FLOWER", "CHRYSANTHEMUM"), FlavorDetail.of("DAIRY", "BUTTER"));
+        RecordSaveRequestDto requestDto = RecordSaveRequestDto.builder()
+                .memberId(1L)
+                .alcoholId(1L)
+                .title("Test record")
+                .alcoholIntensity(AlcoholIntensity.STRONG)
+                .flavorTagList(flavorDetailList)
+                .tasteScore(4)
+                .textureScore(5)
+                .description("This is a test record.")
+                .experienceDate(LocalDate.now())
+                .build();
+
+        List<MockMultipartFile> mockMultipartFiles = Arrays.asList(
+                new MockMultipartFile("photoList", "test1.jpg", "image/jpeg", "test1".getBytes()),
+                new MockMultipartFile("photoList", "test2.jpg", "image/jpeg", "test2".getBytes()));
+
+
+        // when, then
+        mockMvc.perform(multipart("/records")
+                        .file(mockMultipartFiles.get(0))
+                        .file(mockMultipartFiles.get(1))
+                        .file(new MockMultipartFile("recordInfo", "", "application/json",  objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8))))
+                .andExpect(status().isCreated())
+                .andDo(document("save-record",
+                        requestParts(List.of(
+                                partWithName("photoList").description("사용자가 업로드한 이미지 리스트(0 ~ 3장)").optional(),
+                                partWithName("recordInfo").description("사용자가 작성한 전통주 경험")
+                        )),
+                        requestPartFields("recordInfo", List.of(
+                                fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("작성자 id"),
+                                fieldWithPath("alcoholId").type(JsonFieldType.NUMBER).description("술 id"),
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("alcoholIntensity").type(JsonFieldType.STRING).description("도수 느낌"),
+                                fieldWithPath("flavorTagList").type(JsonFieldType.ARRAY).description("상세 플레이버(optional)").optional(),
+                                fieldWithPath("flavorTagList[0].majorTag").type(JsonFieldType.STRING).description("2분류").optional(),
+                                fieldWithPath("flavorTagList[0].detailTag").type(JsonFieldType.STRING).description("3분류").optional(),
+                                fieldWithPath("tasteScore").type(JsonFieldType.NUMBER).description("맛점수 (1~5)"),
+                                fieldWithPath("textureScore").type(JsonFieldType.NUMBER).description("감촉점수 (1~5)"),
+                                fieldWithPath("description").type(JsonFieldType.STRING).description("상세 내용"),
+                                fieldWithPath("experienceDate").type(JsonFieldType.STRING).description("경험 날짜")
+                        ))
+                ));
+    }
+}


### PR DESCRIPTION
## 개요
- 전통주 경험 저장 api 개발

## 작업사항
- 전통주(record) 도메인 entity, dto 추가
- 이미지 저장 service 레이어 클래스 추가 (인프라 작업 필요 #8)
- record 도메인 service 레이어 클래스 추가
- 관련 mapper 로직 추가(#4 반영 후 typehandler 로직 테스트 필요)

## 변경로직
- N/A

## 참고
~도수 어땠는지 변수명, db 저장타입 수정했습니다!~
~- as-is: alcohol_percent_feeling, int~
~- to-be: AlcoholIntensity, string(enum 그대로)~