### PR TITLE
feat: 엔티티 멤버변수로 오브젝트 가지던 구조에서 id값만 가지도록 수정

### DIFF
--- a/backend/src/main/java/sullog/backend/alcohol/entity/Alcohol.java
+++ b/backend/src/main/java/sullog/backend/alcohol/entity/Alcohol.java
@@ -1,7 +1,6 @@
 package sullog.backend.alcohol.entity;
 
 import lombok.Builder;
-import lombok.Getter;
 import lombok.ToString;
 import sullog.backend.common.entity.BaseEntity;
 
@@ -24,7 +23,39 @@ public class Alcohol extends BaseEntity {
 
     private String alcoholTag;
 
-    private AlcoholBrand alcoholBrand;
+    private int brandId;
+
+    public int getAlcoholId() {
+        return alcoholId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getAlcoholPercent() {
+        return alcoholPercent;
+    }
+
+    public String getProductionLocation() {
+        return productionLocation;
+    }
+
+    public double getProductionLatitude() {
+        return productionLatitude;
+    }
+
+    public double getProductionLongitude() {
+        return productionLongitude;
+    }
+
+    public String getAlcoholTag() {
+        return alcoholTag;
+    }
+
+    public int getBrandId() {
+        return brandId;
+    }
 
     @Builder
     public Alcohol(
@@ -35,7 +66,7 @@ public class Alcohol extends BaseEntity {
             double productionLatitude,
             double productionLongitude,
             String alcoholTag,
-            AlcoholBrand alcoholBrand,
+            int brandId,
             Instant createdAt,
             Instant updatedAt,
             Instant deletedAt) {
@@ -47,7 +78,7 @@ public class Alcohol extends BaseEntity {
         this.productionLatitude = productionLatitude;
         this.productionLongitude = productionLongitude;
         this.alcoholTag = alcoholTag;
-        this.alcoholBrand = alcoholBrand;
+        this.brandId = brandId;
     }
 
 }

--- a/backend/src/main/java/sullog/backend/common/entity/BaseEntity.java
+++ b/backend/src/main/java/sullog/backend/common/entity/BaseEntity.java
@@ -8,7 +8,9 @@ import java.time.Instant;
 public class BaseEntity {
 
     private final Instant createdAt;
+
     private final Instant updatedAt;
+
     private final Instant deletedAt;
 
     public BaseEntity(

--- a/backend/src/main/java/sullog/backend/member/entity/Member.java
+++ b/backend/src/main/java/sullog/backend/member/entity/Member.java
@@ -9,7 +9,9 @@ import java.time.Instant;
 @ToString(callSuper = true)
 public class Member extends BaseEntity {
 
-    private final String memberId;
+    private final int memberId;
+
+    private final String email;
 
     private final String nickname;
 
@@ -17,7 +19,8 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(
-            String memberId,
+            int memberId,
+            String email,
             String nickname,
             String searchWordList,
             Instant createdAt,
@@ -25,12 +28,17 @@ public class Member extends BaseEntity {
             Instant deletedAt) {
         super(createdAt, updatedAt, deletedAt);
         this.memberId = memberId;
+        this.email = email;
         this.nickname = nickname;
         this.searchWordList = searchWordList;
     }
 
-    public String getMemberId() {
+    public int getMemberId() {
         return memberId;
+    }
+
+    public String getEmail() {
+        return email;
     }
 
     public String getNickname() {

--- a/backend/src/main/java/sullog/backend/record/entity/Record.java
+++ b/backend/src/main/java/sullog/backend/record/entity/Record.java
@@ -1,26 +1,25 @@
 package sullog.backend.record.entity;
 
 import lombok.Builder;
-import lombok.Getter;
 import lombok.ToString;
-import sullog.backend.alcohol.entity.Alcohol;
 import sullog.backend.common.entity.BaseEntity;
-import sullog.backend.member.entity.Member;
 
 import java.time.Instant;
 
 @ToString(callSuper = true)
 public class Record extends BaseEntity {
 
-    private double recordId;
+    private int recordId;
 
     private String title;
 
-    private String photoPath;
+    private String photoPathList;
 
     private String alcoholPercentFeeling;
 
     private String flavorTagList;
+
+    private int scentScore;
 
     private int tasteScore;
 
@@ -28,51 +27,41 @@ public class Record extends BaseEntity {
 
     private String description;
 
-    private Member member;
+    private int memberId;
 
-    private Alcohol alcohol;
-
-    private String imagePath1;
-
-    private String imagePath2;
-
-    private String imagePath3;
+    private int alcoholId;
 
     @Builder
     public Record(
-            double recordId,
-            String title,
-            String photoPath,
-            String alcoholPercentFeeling,
-            String flavorTagList,
-            int tasteScore,
-            int textureScore,
-            String description,
-            Member member,
-            Alcohol alcohol,
             Instant createdAt,
             Instant updatedAt,
             Instant deletedAt,
-            String imagePath1,
-            String imagePath2,
-            String imagePath3) {
+            int recordId,
+            String title,
+            String photoPathList,
+            String alcoholPercentFeeling,
+            String flavorTagList,
+            int scentScore,
+            int tasteScore,
+            int textureScore,
+            String description,
+            int memberId,
+            int alcoholId) {
         super(createdAt, updatedAt, deletedAt);
         this.recordId = recordId;
         this.title = title;
-        this.photoPath = photoPath;
+        this.photoPathList = photoPathList;
         this.alcoholPercentFeeling = alcoholPercentFeeling;
         this.flavorTagList = flavorTagList;
+        this.scentScore = scentScore;
         this.tasteScore = tasteScore;
         this.textureScore = textureScore;
         this.description = description;
-        this.member = member;
-        this.alcohol = alcohol;
-        this.imagePath1 = imagePath1;
-        this.imagePath2 = imagePath2;
-        this.imagePath3 = imagePath3;
+        this.memberId = memberId;
+        this.alcoholId = alcoholId;
     }
 
-    public double getRecordId() {
+    public int getRecordId() {
         return recordId;
     }
 
@@ -80,8 +69,8 @@ public class Record extends BaseEntity {
         return title;
     }
 
-    public String getPhotoPath() {
-        return photoPath;
+    public String getPhotoPathList() {
+        return photoPathList;
     }
 
     public String getAlcoholPercentFeeling() {
@@ -90,6 +79,10 @@ public class Record extends BaseEntity {
 
     public String getFlavorTagList() {
         return flavorTagList;
+    }
+
+    public int getScentScore() {
+        return scentScore;
     }
 
     public int getTasteScore() {
@@ -104,23 +97,11 @@ public class Record extends BaseEntity {
         return description;
     }
 
-    public Member getMember() {
-        return member;
+    public int getMemberId() {
+        return memberId;
     }
 
-    public Alcohol getAlcohol() {
-        return alcohol;
-    }
-
-    public String getImagePath1() {
-        return imagePath1;
-    }
-
-    public String getImagePath2() {
-        return imagePath2;
-    }
-
-    public String getImagePath3() {
-        return imagePath3;
+    public int getAlcoholId() {
+        return alcoholId;
     }
 }


### PR DESCRIPTION
## 개요
- 엔티티 멤버변수로 오브젝트 가지던 구조에서 id값만 가지도록 수정

## 작업사항
- Alcohol, Member, Record 클래스 의존관계였던 멤버변수들 수정함

## 변경로직
- N/A

## 참고
- 앞으로 join 쿼리를 리턴받을 dto의 경우 dto.table 패키지에 생성하고, xml에서는 ResultMap을 사용해 정확하게 dto와 매핑될 수 있도록 할 것
