### PR TITLE
[회원관리] 회원 탈퇴 API

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -42,7 +42,6 @@ include::{snippets}/token-refresh/response-headers.adoc[]
 ===== Request
 include::{snippets}/member/delete-member/http-request.adoc[]
 include::{snippets}/member/delete-member/request-headers.adoc[]
-include::{snippets}/member/delete-member/path-parameters.adoc[]
 
 ===== Response
 include::{snippets}/member/delete-member/http-response.adoc[]

--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -37,3 +37,12 @@ include::{snippets}/token-refresh/http-request.adoc[]
 ===== Response
 include::{snippets}/token-refresh/http-response.adoc[]
 include::{snippets}/token-refresh/response-headers.adoc[]
+
+==== 회원 탈퇴
+===== Request
+include::{snippets}/member/delete-member/http-request.adoc[]
+include::{snippets}/member/delete-member/request-headers.adoc[]
+include::{snippets}/member/delete-member/path-parameters.adoc[]
+
+===== Response
+include::{snippets}/member/delete-member/http-response.adoc[]

--- a/backend/src/main/java/sullog/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/MemberController.java
@@ -1,0 +1,21 @@
+package sullog.backend.member.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import sullog.backend.member.service.MemberService;
+
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @DeleteMapping("/members/{memberId}")
+    public void deleteMember(@PathVariable int memberId){
+        memberService.deleteMember(memberId);
+    }
+}

--- a/backend/src/main/java/sullog/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/MemberController.java
@@ -1,21 +1,25 @@
 package sullog.backend.member.controller;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import sullog.backend.member.service.MemberService;
+import sullog.backend.member.service.TokenService;
 
 @RestController
 public class MemberController {
 
+    private final TokenService tokenService;
     private final MemberService memberService;
 
-    public MemberController(MemberService memberService) {
+    public MemberController(TokenService tokenService, MemberService memberService) {
+        this.tokenService = tokenService;
         this.memberService = memberService;
     }
 
-    @DeleteMapping("/members/{memberId}")
-    public void deleteMember(@PathVariable int memberId){
-        memberService.deleteMember(memberId);
+    @DeleteMapping("/members/me")
+    public void deleteMember(@RequestHeader String authorization){
+        String email = tokenService.getEmail(authorization);
+        memberService.deleteMember(email);
     }
 }

--- a/backend/src/main/java/sullog/backend/member/mapper/MemberMapper.java
+++ b/backend/src/main/java/sullog/backend/member/mapper/MemberMapper.java
@@ -9,4 +9,5 @@ public interface MemberMapper {
 
     void insertMember(Member member) throws RuntimeException;
     Member selectMemberByEmail(@Param("email") String email);
+    void deleteMemberById(@Param("memberId") int memberId);
 }

--- a/backend/src/main/java/sullog/backend/member/mapper/MemberMapper.java
+++ b/backend/src/main/java/sullog/backend/member/mapper/MemberMapper.java
@@ -9,5 +9,5 @@ public interface MemberMapper {
 
     void insertMember(Member member) throws RuntimeException;
     Member selectMemberByEmail(@Param("email") String email);
-    void deleteMemberById(@Param("memberId") int memberId);
+    void deleteMemberByEmail(@Param("email") String email);
 }

--- a/backend/src/main/java/sullog/backend/member/service/MemberService.java
+++ b/backend/src/main/java/sullog/backend/member/service/MemberService.java
@@ -28,4 +28,8 @@ public class MemberService {
     public Member findMemberByEmail(String email) {
         return memberMapper.selectMemberByEmail(email);
     }
+
+    public void deleteMember(int memberId) {
+        memberMapper.deleteMemberById(memberId);
+    }
 }

--- a/backend/src/main/java/sullog/backend/member/service/MemberService.java
+++ b/backend/src/main/java/sullog/backend/member/service/MemberService.java
@@ -29,7 +29,7 @@ public class MemberService {
         return memberMapper.selectMemberByEmail(email);
     }
 
-    public void deleteMember(int memberId) {
-        memberMapper.deleteMemberById(memberId);
+    public void deleteMember(String email) {
+        memberMapper.deleteMemberByEmail(email);
     }
 }

--- a/backend/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/src/main/resources/mapper/member/MemberMapper.xml
@@ -24,13 +24,13 @@
         WHERE email = #{email} and deleted_at = NULL
     </select>
 
-    <delete id="deleteMemberById">
+    <delete id="deleteMemberByEmail">
         UPDATE member
         SET
             deleted_at = NOW(),
             updated_at = NOW()
         WHERE
-            member_id = #{memberId}
+            email = #{email}
     </delete>
 
 </mapper>

--- a/backend/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/src/main/resources/mapper/member/MemberMapper.xml
@@ -19,6 +19,18 @@
     </insert>
 
     <select id="selectMemberByEmail" resultType="sullog.backend.member.entity.Member">
-        SELECT * FROM member WHERE email = #{email}
+        SELECT *
+        FROM member
+        WHERE email = #{email} and deleted_at = NULL
     </select>
+
+    <delete id="deleteMemberById">
+        UPDATE member
+        SET
+            deleted_at = NOW(),
+            updated_at = NOW()
+        WHERE
+            member_id = #{memberId}
+    </delete>
+
 </mapper>

--- a/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
@@ -1,0 +1,75 @@
+package sullog.backend.member.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import sullog.backend.member.config.jwt.JwtAuthFilter;
+import sullog.backend.member.service.MemberService;
+import sullog.backend.member.service.TokenService;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete; // MockMvcBuilders 사용하면 pathParameters 이용 시 에러발생
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+@ExtendWith(RestDocumentationExtension.class)
+class MemberControllerTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtAuthFilter jwtAuthFilter;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .alwaysDo(MockMvcResultHandlers.print())
+                .build();
+    }
+
+    @Test
+    void memberId값을_바탕으로_회원탈퇴를_진행한다() throws Exception {
+        // given
+        int memberId = 0;
+        String accessToken = "sample_token";
+
+        // when
+        doNothing().when(memberService).deleteMember(memberId);
+
+        // then
+        this.mockMvc.perform(delete("/members/{memberId}", memberId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andDo(document("member/delete-member",
+                        pathParameters(
+                                parameterWithName("memberId").description("탈퇴하려는 member의 id")
+                        ),
+                        requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("사용자의 access token")
+                )));
+    }
+
+}

--- a/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
@@ -17,12 +17,11 @@ import sullog.backend.member.service.MemberService;
 import sullog.backend.member.service.TokenService;
 
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete; // MockMvcBuilders 사용하면 pathParameters 이용 시 에러발생
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
@@ -52,21 +51,19 @@ class MemberControllerTest {
     @Test
     void memberId값을_바탕으로_회원탈퇴를_진행한다() throws Exception {
         // given
-        int memberId = 0;
+        String email = "test@test.com";
         String accessToken = "sample_token";
 
         // when
-        doNothing().when(memberService).deleteMember(memberId);
+        doReturn(email).when(tokenService).getEmail(accessToken);
+        doNothing().when(memberService).deleteMember(email);
 
         // then
-        this.mockMvc.perform(delete("/members/{memberId}", memberId)
+        this.mockMvc.perform(delete("/members/me")
                         .header(HttpHeaders.AUTHORIZATION, accessToken))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
                 .andDo(document("member/delete-member",
-                        pathParameters(
-                                parameterWithName("memberId").description("탈퇴하려는 member의 id")
-                        ),
                         requestHeaders(
                             headerWithName(HttpHeaders.AUTHORIZATION).description("사용자의 access token")
                 )));


### PR DESCRIPTION
## 개요
- 회원 탈퇴 관련 API 추가

## 작업사항
- 회원 탈퇴 api end-point 추가
- 멤버 삭제 처리하는 service 로직 추가
- 멤버 튜플 soft delete 하는 mapper 로직 추가
- 정상케이스에 대한 테스트 코드 추가(rest-docs 반영)

## 변경로직
- N/A

## 기타
고민거리: memberId를 pathvariable로 받지 않고, access token 기반으로 뽑아서 처리하는게 맞지 않을지...!?!!(지난번에 간단히 논의한 내용)
-> /me로 처리하기로 결정
