### PR TITLE
사용자 id 기반 경험기록 조회 api

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -59,12 +59,12 @@ include::{snippets}/record/save-record/http-response.adoc[]
 
 ==== 특정 사용자의 전통주 경험 조회
 ===== Request
-include::{snippets}/record/get-record-by-memberId/http-request.adoc[]
-include::{snippets}/record/get-record-by-memberId/request-parameters.adoc[]
+include::{snippets}/record/get-records-by-memberId/http-request.adoc[]
+include::{snippets}/record/get-records-by-memberId/request-parameters.adoc[]
 
 ===== Response
-include::{snippets}/record/get-record-by-memberId/http-response.adoc[]
-include::{snippets}/record/get-record-by-memberId/response-fields.adoc[]
+include::{snippets}/record/get-records-by-memberId/http-response.adoc[]
+include::{snippets}/record/get-records-by-memberId/response-fields.adoc[]
 
 == 4. 전통주 조회
 ==== 전통주 검색

--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -57,6 +57,15 @@ include::{snippets}/record/save-record/request-part-recordInfo-fields.adoc[]
 ===== Response
 include::{snippets}/record/save-record/http-response.adoc[]
 
+==== 특정 사용자의 전통주 경험 조회
+===== Request
+include::{snippets}/record/get-record-by-memberId/http-request.adoc[]
+include::{snippets}/record/get-record-by-memberId/request-parameters.adoc[]
+
+===== Response
+include::{snippets}/record/get-record-by-memberId/http-response.adoc[]
+include::{snippets}/record/get-record-by-memberId/response-fields.adoc[]
+
 == 4. 전통주 조회
 ==== 전통주 검색
 ===== Request

--- a/backend/src/main/java/sullog/backend/common/config/MybatisConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/MybatisConfig.java
@@ -1,5 +1,6 @@
 package sullog.backend.common.config;
 
+import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.type.TypeHandler;
 import org.mybatis.spring.SqlSessionFactoryBean;
@@ -19,7 +20,7 @@ import sullog.backend.record.mapper.typehandler.FlavorTagListTypeHandler;
 import javax.sql.DataSource;
 
 @Configuration
-@MapperScan(value = "sullog.backend", sqlSessionFactoryRef = "factory")
+@MapperScan(value = "sullog.backend", sqlSessionFactoryRef = "factory", annotationClass = Mapper.class)
 public class MybatisConfig {
 
     @Bean(name = "datasource")
@@ -35,9 +36,9 @@ public class MybatisConfig {
         PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
         sqlSessionFactory.setMapperLocations(resolver.getResources("classpath:/mapper/**/*.xml"));
         sqlSessionFactory.setTypeHandlers(new TypeHandler[] {
-                new StringListTypeHandler(),
                 new AlcoholPercentFeelingTypeHandler(AlcoholPercentFeeling.class),
-                new FlavorTagListTypeHandler()
+                new FlavorTagListTypeHandler(),
+                new StringListTypeHandler()
         });
         return sqlSessionFactory.getObject();
     }

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -4,10 +4,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import sullog.backend.record.dto.RecordSaveRequestDto;
+import sullog.backend.record.dto.response.RecordMetaDto;
+import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.service.ImageUploadService;
 import sullog.backend.record.service.RecordService;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 public class RecordController {
@@ -30,5 +33,11 @@ public class RecordController {
 
         // 경험기록 저장
         recordService.saveRecord(requestDto.toEntity(photoPathList));
+    }
+
+    @GetMapping("/records")
+    public List<RecordMetaDto> getRecords(@RequestParam int memberId) {
+        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByMemberId(memberId);
+        return recordMetaWithAlcoholInfoList.stream().map(RecordMetaWithAlcoholInfoDto::toResponseDto).collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaDto.java
@@ -9,9 +9,12 @@ public class RecordMetaDto {
     private String description; // 경험기록 상세내용
     private String mainPhotoPath; // 사용자가 등록한 사진 경로(optional)
     private int alcoholId; // 전통주 id
+    private String alcoholName; // 전통주 이름
+    private String productionLocation; // 생산지 명
     private double productionLatitude; // 전통주 생산지 위도
     private double productionLongitude; // 전통주 생산지 경도
     private String alcoholTag; // 전통주 태그
+    private String brandName; // 브랜드 이름
 
     public int getRecordId() {
         return recordId;
@@ -29,6 +32,14 @@ public class RecordMetaDto {
         return alcoholId;
     }
 
+    public String getAlcoholName() {
+        return alcoholName;
+    }
+
+    public String getProductionLocation() {
+        return productionLocation;
+    }
+
     public double getProductionLatitude() {
         return productionLatitude;
     }
@@ -39,5 +50,9 @@ public class RecordMetaDto {
 
     public String getAlcoholTag() {
         return alcoholTag;
+    }
+
+    public String getBrandName() {
+        return brandName;
     }
 }

--- a/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaDto.java
@@ -1,0 +1,43 @@
+package sullog.backend.record.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class RecordMetaDto {
+
+    private int recordId; // 경험기록 id
+    private String description; // 경험기록 상세내용
+    private String mainPhotoPath; // 사용자가 등록한 사진 경로(optional)
+    private int alcoholId; // 전통주 id
+    private double productionLatitude; // 전통주 생산지 위도
+    private double productionLongitude; // 전통주 생산지 경도
+    private String alcoholTag; // 전통주 태그
+
+    public int getRecordId() {
+        return recordId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getMainPhotoPath() {
+        return mainPhotoPath;
+    }
+
+    public int getAlcoholId() {
+        return alcoholId;
+    }
+
+    public double getProductionLatitude() {
+        return productionLatitude;
+    }
+
+    public double getProductionLongitude() {
+        return productionLongitude;
+    }
+
+    public String getAlcoholTag() {
+        return alcoholTag;
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
@@ -12,6 +12,8 @@ public class RecordMetaWithAlcoholInfoDto {
     private String description;
     private List<String> photoPathList;
     private int alcoholId;
+    private String alcoholName;
+    private String productionLocation;
     private double productionLatitude;
     private double productionLongitude;
     private String alcoholTag;
@@ -32,6 +34,14 @@ public class RecordMetaWithAlcoholInfoDto {
         return alcoholId;
     }
 
+    public String getAlcoholName() {
+        return alcoholName;
+    }
+
+    public String getProductionLocation() {
+        return productionLocation;
+    }
+
     public double getProductionLatitude() {
         return productionLatitude;
     }
@@ -50,6 +60,8 @@ public class RecordMetaWithAlcoholInfoDto {
                 .description(description)
                 .mainPhotoPath(getMainPhotoPath())
                 .alcoholId(alcoholId)
+                .alcoholName(alcoholName)
+                .productionLocation(productionLocation)
                 .productionLatitude(productionLatitude)
                 .productionLongitude(productionLongitude)
                 .alcoholTag(alcoholTag)

--- a/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
@@ -17,6 +17,7 @@ public class RecordMetaWithAlcoholInfoDto {
     private double productionLatitude;
     private double productionLongitude;
     private String alcoholTag;
+    private String brandName;
 
     public int getRecordId() {
         return recordId;
@@ -65,6 +66,7 @@ public class RecordMetaWithAlcoholInfoDto {
                 .productionLatitude(productionLatitude)
                 .productionLongitude(productionLongitude)
                 .alcoholTag(alcoholTag)
+                .brandName(brandName)
                 .build();
     }
 

--- a/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
@@ -1,0 +1,66 @@
+package sullog.backend.record.dto.table;
+
+import lombok.Builder;
+import sullog.backend.record.dto.response.RecordMetaDto;
+
+import java.util.List;
+
+@Builder
+public class RecordMetaWithAlcoholInfoDto {
+
+    private int recordId;
+    private String description;
+    private List<String> photoPathList;
+    private int alcoholId;
+    private double productionLatitude;
+    private double productionLongitude;
+    private String alcoholTag;
+
+    public int getRecordId() {
+        return recordId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<String> getPhotoPathList() {
+        return photoPathList;
+    }
+
+    public int getAlcoholId() {
+        return alcoholId;
+    }
+
+    public double getProductionLatitude() {
+        return productionLatitude;
+    }
+
+    public double getProductionLongitude() {
+        return productionLongitude;
+    }
+
+    public String getAlcoholTag() {
+        return alcoholTag;
+    }
+
+    public RecordMetaDto toResponseDto() {
+        return RecordMetaDto.builder()
+                .recordId(recordId)
+                .description(description)
+                .mainPhotoPath(getMainPhotoPath())
+                .alcoholId(alcoholId)
+                .productionLatitude(productionLatitude)
+                .productionLongitude(productionLongitude)
+                .alcoholTag(alcoholTag)
+                .build();
+    }
+
+    private String getMainPhotoPath() {
+        if(photoPathList.isEmpty()) {
+            return "";
+        }
+
+        return photoPathList.get(0);
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
@@ -1,10 +1,15 @@
 package sullog.backend.record.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
+
+import java.util.List;
 
 @Mapper
 public interface RecordMapper {
 
     void insertRecord(Record record);
+
+    List<RecordMetaWithAlcoholInfoDto> selectRecordMetaByMemberId(int memberId);
 }

--- a/backend/src/main/java/sullog/backend/record/service/RecordService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordService.java
@@ -1,8 +1,11 @@
 package sullog.backend.record.service;
 
 import org.springframework.stereotype.Service;
+import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
 import sullog.backend.record.mapper.RecordMapper;
+
+import java.util.List;
 
 @Service
 public class RecordService {
@@ -15,5 +18,10 @@ public class RecordService {
 
     public void saveRecord(Record record) {
         recordMapper.insertRecord(record);
+    }
+
+    public List<RecordMetaWithAlcoholInfoDto> getRecordMetasByMemberId(int memberId) {
+        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoDtos = recordMapper.selectRecordMetaByMemberId(memberId);
+        return recordMetaWithAlcoholInfoDtos;
     }
 }

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -44,6 +44,7 @@
         <result property="productionLatitude" column="production_latitude"/>
         <result property="productionLongitude" column="production_longitude"/>
         <result property="alcoholTag" column="alcohol_tag"/>
+        <result property="brandName" column="brand_name"/>
     </resultMap>
 
     <select id="selectRecordMetaByMemberId" resultMap="RecordMetaWithAlcoholInfo">
@@ -51,19 +52,23 @@
                r.description          AS description,
                r.photo_path           AS photo_path,
                a.alcohol_id           AS alcohol_id,
-               a.name         AS alcohol_name,
+               a.name                 AS alcohol_name,
                a.production_location  AS production_location,
                a.production_latitude  AS production_latitude,
                a.production_longitude AS production_longitude,
-               a.alcohol_tag          AS alcohol_tag
+               a.alcohol_tag          AS alcohol_tag,
+               ab.name                AS brand_name
         FROM record AS r
-            LEFT JOIN (SELECT alcohol_id,
-                              name,
-                              production_location,
-                              production_latitude,
-                              production_longitude,
-                              alcohol_tag
-                       FROM alcohol) AS a
-            ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
+        LEFT JOIN (SELECT alcohol_id,
+                          brand_id,
+                          name,
+                          production_location,
+                          production_latitude,
+                          production_longitude,
+                          alcohol_tag
+                    FROM alcohol) AS a
+        ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
+        LEFT JOIN alcohol_brand AS ab
+        ON a.brand_id = ab.brand_id
     </select>
 </mapper>

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -39,6 +39,8 @@
         <result property="description" column="description"/>
         <result property="photoPathList" column="photo_path" typeHandler="sullog.backend.common.mapper.typehandler.StringListTypeHandler"/>
         <result property="alcoholId" column="alcohol_id"/>
+        <result property="alcoholName" column="alcohol_name"/>
+        <result property="productionLocation" column="production_location"/>
         <result property="productionLatitude" column="production_latitude"/>
         <result property="productionLongitude" column="production_longitude"/>
         <result property="alcoholTag" column="alcohol_tag"/>
@@ -49,11 +51,15 @@
                r.description          AS description,
                r.photo_path           AS photo_path,
                a.alcohol_id           AS alcohol_id,
+               a.name         AS alcohol_name,
+               a.production_location  AS production_location,
                a.production_latitude  AS production_latitude,
                a.production_longitude AS production_longitude,
                a.alcohol_tag          AS alcohol_tag
         FROM record AS r
             LEFT JOIN (SELECT alcohol_id,
+                              name,
+                              production_location,
                               production_latitude,
                               production_longitude,
                               alcohol_tag

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -33,4 +33,31 @@
                    #{experienceDate}
                );
     </insert>
+
+    <resultMap id="RecordMetaWithAlcoholInfo" type="sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto">
+        <result property="recordId" column="record_id"/>
+        <result property="description" column="description"/>
+        <result property="photoPathList" column="photo_path" typeHandler="sullog.backend.common.mapper.typehandler.StringListTypeHandler"/>
+        <result property="alcoholId" column="alcohol_id"/>
+        <result property="productionLatitude" column="production_latitude"/>
+        <result property="productionLongitude" column="production_longitude"/>
+        <result property="alcoholTag" column="alcohol_tag"/>
+    </resultMap>
+
+    <select id="selectRecordMetaByMemberId" resultMap="RecordMetaWithAlcoholInfo">
+        SELECT r.record_id            AS record_id,
+               r.description          AS description,
+               r.photo_path           AS photo_path,
+               a.alcohol_id           AS alcohol_id,
+               a.production_latitude  AS production_latitude,
+               a.production_longitude AS production_longitude,
+               a.alcohol_tag          AS alcohol_tag
+        FROM record AS r
+            LEFT JOIN (SELECT alcohol_id,
+                              production_latitude,
+                              production_longitude,
+                              alcohol_tag
+                       FROM alcohol) AS a
+            ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
+    </select>
 </mapper>

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -165,7 +165,8 @@ class RecordControllerTest {
                                 fieldWithPath("[].productionLocation").description("전통주 생산지 명"),
                                 fieldWithPath("[].productionLatitude").description("전통주 생산지 위도"),
                                 fieldWithPath("[].productionLongitude").description("전통주 생산지 경도"),
-                                fieldWithPath("[].alcoholTag").description("전통주 태그")
+                                fieldWithPath("[].alcoholTag").description("전통주 태그"),
+                                fieldWithPath("[].brandName").description("브랜드 이름")
                         ))
                 );
     }
@@ -181,6 +182,7 @@ class RecordControllerTest {
                 .productionLatitude(37.123456)
                 .productionLongitude(126.789012)
                 .alcoholTag("SOJU")
+                .brandName("진로")
                 .build();
 
         RecordMetaWithAlcoholInfoDto recordMetaWithAlcoholInfoDto2 = RecordMetaWithAlcoholInfoDto.builder()
@@ -193,6 +195,7 @@ class RecordControllerTest {
                 .productionLatitude(36.987654)
                 .productionLongitude(127.012345)
                 .alcoholTag("FRUIT_WINE")
+                .brandName("진로")
                 .build();
 
         RecordMetaWithAlcoholInfoDto recordMetaWithAlcoholInfoDto3 = RecordMetaWithAlcoholInfoDto.builder()
@@ -205,6 +208,7 @@ class RecordControllerTest {
                 .productionLatitude(35.123456)
                 .productionLongitude(128.789012)
                 .alcoholTag("MAKGEOLLI")
+                .brandName("진로")
                 .build();
 
         return List.of(recordMetaWithAlcoholInfoDto, recordMetaWithAlcoholInfoDto2, recordMetaWithAlcoholInfoDto3);

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -150,7 +150,7 @@ class RecordControllerTest {
                 .andExpect(jsonPath("$[0].productionLatitude", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLatitude())))
                 .andExpect(jsonPath("$[0].productionLongitude", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLongitude())))
                 .andExpect(jsonPath("$[0].alcoholTag", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getAlcoholTag())))
-                .andDo(document("record/get-record-by-memberId",
+                .andDo(document("record/get-records-by-memberId",
                         requestParameters(
                                 parameterWithName("memberId").description("조회할 멤버의 ID")
                         ),

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -147,6 +147,8 @@ class RecordControllerTest {
                 .andExpect(jsonPath("$[0].description", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getDescription())))
                 .andExpect(jsonPath("$[0].mainPhotoPath", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getMainPhotoPath())))
                 .andExpect(jsonPath("$[0].alcoholId", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getAlcoholId())))
+                .andExpect(jsonPath("$[0].alcoholName", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getAlcoholName())))
+                .andExpect(jsonPath("$[0].productionLocation", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLocation())))
                 .andExpect(jsonPath("$[0].productionLatitude", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLatitude())))
                 .andExpect(jsonPath("$[0].productionLongitude", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLongitude())))
                 .andExpect(jsonPath("$[0].alcoholTag", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getAlcoholTag())))
@@ -159,6 +161,8 @@ class RecordControllerTest {
                                 fieldWithPath("[].description").description("경험기록 상세내용"),
                                 fieldWithPath("[].mainPhotoPath").description("사용자가 업로드한 사진 경로(없을 경우, 빈 문자열(\"\")"),
                                 fieldWithPath("[].alcoholId").description("전통주 ID"),
+                                fieldWithPath("[].alcoholName").description("전통주 이름"),
+                                fieldWithPath("[].productionLocation").description("전통주 생산지 명"),
                                 fieldWithPath("[].productionLatitude").description("전통주 생산지 위도"),
                                 fieldWithPath("[].productionLongitude").description("전통주 생산지 경도"),
                                 fieldWithPath("[].alcoholTag").description("전통주 태그")
@@ -172,6 +176,8 @@ class RecordControllerTest {
                 .description("This is a first sample record.")
                 .photoPathList(Arrays.asList("path/to/photo1.jpg", "path/to/photo2.jpg"))
                 .alcoholId(1)
+                .alcoholName("test1")
+                .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(37.123456)
                 .productionLongitude(126.789012)
                 .alcoholTag("SOJU")
@@ -182,6 +188,8 @@ class RecordControllerTest {
                 .description("This is a second sample record.")
                 .photoPathList(Arrays.asList("path/to/photo3.jpg", "path/to/photo4.jpg"))
                 .alcoholId(2)
+                .alcoholName("test2")
+                .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(36.987654)
                 .productionLongitude(127.012345)
                 .alcoholTag("FRUIT_WINE")
@@ -192,6 +200,8 @@ class RecordControllerTest {
                 .description("This is a third sample record.")
                 .photoPathList(Arrays.asList("path/to/photo5.jpg", "path/to/photo6.jpg"))
                 .alcoholId(3)
+                .alcoholName("test3")
+                .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(35.123456)
                 .productionLongitude(128.789012)
                 .alcoholTag("MAKGEOLLI")


### PR DESCRIPTION
## 개요
- 사용자 id 기반 경험기록 조회 api

## 작업사항
- 컨트롤러, 서비스, 매퍼 로직 추가
- 쿼리는 record, alcohol 테이블 join 해서 사용

## 변경로직
- mybatis config 수정
  - @Mapper 붙은 인터페이스만 mybatis 프록시 객체로 생성하도록 수정(이렇게 하지 않으면, mapperscan범위가 크기때문에 그냥 일반 interface도 mybatis객체로 만들어버림..)
  -  List<String> 타입 변수의 타입핸들러 지정을 위한, 선언순서 변경(#30 참고)

## 기타
고민했던 점은.. join query 짤 때 특정 member_id 에 대한 데이터를 가져오는 것이기 때문에 where 또는 join 시 on 할 때 조건을 줘야했는데, join을 만드는 테이블을 줄이는게 더 성능상 좋을것 같아서 on에 추가하였습니다 !
