### PR TITLE
json으로 변환 시 null이면 출력되지 않도록 어노테이션 추가

### DIFF
--- a/backend/src/main/java/sullog/backend/common/entity/BaseEntity.java
+++ b/backend/src/main/java/sullog/backend/common/entity/BaseEntity.java
@@ -1,10 +1,12 @@
 package sullog.backend.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.ToString;
 
 import java.time.Instant;
 
 @ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BaseEntity {
 
     private final Instant createdAt;
@@ -20,6 +22,12 @@ public class BaseEntity {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;
+    }
+
+    public BaseEntity() {
+        this.createdAt = null;
+        this.updatedAt = null;
+        this.deletedAt = null;
     }
 
     public Instant getCreatedAt() {


### PR DESCRIPTION
## 개요
- response 출력시 baseEntity 값이 null인 경우가 많은데, null이 출력되는 것보다 제외되는 편이 나아보여서 작업(참고: https://junho85.pe.kr/1626)

## 작업사항
- json으로 변환 시 null이면 출력되지 않도록 어노테이션 추가
- 기본 생성자 추가(resultMap에서 record 클래스 접근하니, 기본생성자가 없어서 오류가 발생하고 있어서 추가했습니다~~)

## 변경로직
- N/A
