### PR TITLE
경험기록id기반 경험기록 단건 조회 api 추가

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -59,12 +59,21 @@ include::{snippets}/record/save-record/http-response.adoc[]
 
 ==== 특정 사용자의 전통주 경험 조회
 ===== Request
-include::{snippets}/record/get-record-by-memberId/http-request.adoc[]
-include::{snippets}/record/get-record-by-memberId/request-parameters.adoc[]
+include::{snippets}/record/get-records-by-memberId/http-request.adoc[]
+include::{snippets}/record/get-records-by-memberId/request-parameters.adoc[]
 
 ===== Response
-include::{snippets}/record/get-record-by-memberId/http-response.adoc[]
-include::{snippets}/record/get-record-by-memberId/response-fields.adoc[]
+include::{snippets}/record/get-records-by-memberId/http-response.adoc[]
+include::{snippets}/record/get-records-by-memberId/response-fields.adoc[]
+
+==== 경험기록 id 기반 전통주 경험 단건 조회
+===== Request
+include::{snippets}/record/get-record-by-recordId/http-request.adoc[]
+include::{snippets}/record/get-record-by-recordId/path-parameters.adoc[]
+
+===== Response
+include::{snippets}/record/get-record-by-recordId/http-response.adoc[]
+include::{snippets}/record/get-record-by-recordId/response-fields.adoc[]
 
 == 4. 전통주 조회
 ==== 전통주 검색

--- a/backend/src/main/java/sullog/backend/common/config/MybatisConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/MybatisConfig.java
@@ -16,6 +16,7 @@ import sullog.backend.common.mapper.typehandler.StringListTypeHandler;
 import sullog.backend.record.entity.AlcoholPercentFeeling;
 import sullog.backend.record.mapper.typehandler.AlcoholPercentFeelingTypeHandler;
 import sullog.backend.record.mapper.typehandler.FlavorTagListTypeHandler;
+import sullog.backend.record.mapper.typehandler.LocalDateTypeHandler;
 
 import javax.sql.DataSource;
 
@@ -38,7 +39,8 @@ public class MybatisConfig {
         sqlSessionFactory.setTypeHandlers(new TypeHandler[] {
                 new AlcoholPercentFeelingTypeHandler(AlcoholPercentFeeling.class),
                 new FlavorTagListTypeHandler(),
-                new StringListTypeHandler()
+                new StringListTypeHandler(),
+                new LocalDateTypeHandler()
         });
         return sqlSessionFactory.getObject();
     }

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -3,9 +3,13 @@ package sullog.backend.record.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import sullog.backend.alcohol.dto.response.AlcoholInfoDto;
+import sullog.backend.alcohol.service.AlcoholService;
 import sullog.backend.record.dto.RecordSaveRequestDto;
 import sullog.backend.record.dto.response.RecordMetaDto;
+import sullog.backend.record.dto.response.RecordDetailDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
+import sullog.backend.record.entity.Record;
 import sullog.backend.record.service.ImageUploadService;
 import sullog.backend.record.service.RecordService;
 
@@ -17,10 +21,12 @@ public class RecordController {
 
     private final RecordService recordService;
     private final ImageUploadService imageUploadService;
+    private final AlcoholService alcoholService;
 
-    public RecordController(RecordService recordService, ImageUploadService imageUploadService) {
+    public RecordController(RecordService recordService, ImageUploadService imageUploadService, AlcoholService alcoholService) {
         this.recordService = recordService;
         this.imageUploadService = imageUploadService;
+        this.alcoholService = alcoholService;
     }
 
     @PostMapping("/records")
@@ -39,5 +45,15 @@ public class RecordController {
     public List<RecordMetaDto> getRecords(@RequestParam int memberId) {
         List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByMemberId(memberId);
         return recordMetaWithAlcoholInfoList.stream().map(RecordMetaWithAlcoholInfoDto::toResponseDto).collect(Collectors.toList());
+    }
+
+    @GetMapping("/records/{recordId}")
+    public RecordDetailDto getRecord(@PathVariable int recordId) {
+        Record record = recordService.getRecordByRecordId(recordId);
+        AlcoholInfoDto alcoholWithBrand = alcoholService.getAlcoholById(record.getAlcoholId());
+        return RecordDetailDto.builder()
+                .record(record)
+                .alcoholInfo(alcoholWithBrand)
+                .build();
     }
 }

--- a/backend/src/main/java/sullog/backend/record/dto/response/RecordDetailDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/RecordDetailDto.java
@@ -1,0 +1,21 @@
+package sullog.backend.record.dto.response;
+
+import lombok.Builder;
+import sullog.backend.alcohol.dto.response.AlcoholInfoDto;
+import sullog.backend.record.entity.Record;
+
+@Builder
+public class RecordDetailDto {
+
+    private Record record;
+    private AlcoholInfoDto alcoholInfo;
+
+    public Record getRecord() {
+        return record;
+    }
+
+    public AlcoholInfoDto getAlcoholInfo() {
+        return alcoholInfo;
+    }
+
+}

--- a/backend/src/main/java/sullog/backend/record/entity/Record.java
+++ b/backend/src/main/java/sullog/backend/record/entity/Record.java
@@ -34,6 +34,10 @@ public class Record extends BaseEntity {
 
     private LocalDate experienceDate; // 경험 날짜
 
+    public Record() {
+        super();
+    }
+
     @Builder
     public Record(
             Instant createdAt,

--- a/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
@@ -12,4 +12,6 @@ public interface RecordMapper {
     void insertRecord(Record record);
 
     List<RecordMetaWithAlcoholInfoDto> selectRecordMetaByMemberId(int memberId);
+
+    Record selectRecordById(int recordId);
 }

--- a/backend/src/main/java/sullog/backend/record/mapper/typehandler/LocalDateTypeHandler.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/typehandler/LocalDateTypeHandler.java
@@ -1,0 +1,42 @@
+package sullog.backend.record.mapper.typehandler;
+
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+import org.apache.ibatis.type.TypeHandler;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@MappedTypes(LocalDate.class)
+@MappedJdbcTypes(JdbcType.TIMESTAMP)
+public class LocalDateTypeHandler implements TypeHandler<LocalDate> {
+
+
+    @Override
+    public void setParameter(PreparedStatement ps, int i, LocalDate parameter, JdbcType jdbcType) throws SQLException {
+        ps.setObject(i, parameter);
+    }
+
+    @Override
+    public LocalDate getResult(ResultSet rs, String columnName) throws SQLException {
+        LocalDateTime localDateTime = rs.getTimestamp(columnName).toLocalDateTime();
+        return localDateTime.toLocalDate();
+    }
+
+    @Override
+    public LocalDate getResult(ResultSet rs, int columnIndex) throws SQLException {
+        LocalDateTime localDateTime = rs.getTimestamp(columnIndex).toLocalDateTime();
+        return localDateTime.toLocalDate();
+    }
+
+    @Override
+    public LocalDate getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        LocalDateTime localDateTime = cs.getTimestamp(columnIndex).toLocalDateTime();
+        return localDateTime.toLocalDate();
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/service/RecordService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordService.java
@@ -24,4 +24,8 @@ public class RecordService {
         List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoDtos = recordMapper.selectRecordMetaByMemberId(memberId);
         return recordMetaWithAlcoholInfoDtos;
     }
+
+    public Record getRecordByRecordId(int recordId) {
+        return recordMapper.selectRecordById(recordId);
+    }
 }

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -60,4 +60,36 @@
                        FROM alcohol) AS a
             ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
     </select>
+
+    <resultMap id="Record" type="sullog.backend.record.entity.Record">
+        <result property="recordId" column="record_id"/>
+        <result property="memberId" column="member_id"/>
+        <result property="alcoholId" column="alcohol_id"/>
+        <result property="title" column="title"/>
+        <result property="photoPathList" column="photo_path" typeHandler="sullog.backend.common.mapper.typehandler.StringListTypeHandler"/>
+        <result property="alcoholPercentFeeling" column="alcohol_percent_feeling" typeHandler="sullog.backend.record.mapper.typehandler.AlcoholPercentFeelingTypeHandler"/>
+        <result property="flavorTagList" column="flavor_tag_list" typeHandler="sullog.backend.record.mapper.typehandler.FlavorTagListTypeHandler"/>
+        <result property="tasteScore" column="taste_score"/>
+        <result property="scentScore" column="scent_score"/>
+        <result property="textureScore" column="texture_score"/>
+        <result property="description" column="description"/>
+        <result property="experienceDate" column="experience_date" typeHandler="sullog.backend.record.mapper.typehandler.LocalDateTypeHandler"/>
+    </resultMap>
+
+    <select id="selectRecordById" resultMap="Record">
+        SELECT record_id,
+               member_id,
+               alcohol_id,
+               title,
+               photo_path,
+               alcohol_percent_feeling,
+               flavor_tag_list,
+               taste_score,
+               scent_score,
+               texture_score,
+               description,
+               experience_date
+        FROM record
+        WHERE record_id = #{recordId}
+    </select>
 </mapper>


### PR DESCRIPTION
## 개요
- 경험기록id기반 경험기록 단건 조회 api 추가

## 작업사항
- api 처리를 위한 컨트롤러/서비스/mapper 레이어 작업
- LocalDateTypeHandler 추가(mybatis에서 원래 제공하고 있지만, jdbc 버전 이슈로 에러가 계속 발생하여 새로 생성)

## 변경로직
- N/A

## 기타
mybatis에서 제공하는 LocalDateTypeHandler 사용시 발생하는 에러
(jdbc 호환성 이슈라는데.. 관련 모든 라이브러리를 최신화 해보고, 여러 수정해봐도 안되어서 결국 직접 구현)
```
Caused by: java.lang.AbstractMethodError: Receiver class net.sf.log4jdbc.sql.jdbcapi.ResultSetSpy does not define or inherit an implementation of the resolved method 'abstract java.lang.Object getObject(java.lang.String, java.lang.Class)' of interface java.sql.ResultSet.
	at com.zaxxer.hikari.pool.HikariProxyResultSet.getObject(HikariProxyResultSet.java)
	at org.apache.ibatis.type.LocalDateTypeHandler.getNullableResult(LocalDateTypeHandler.java:38)
	at org.apache.ibatis.type.LocalDateTypeHandler.getNullableResult(LocalDateTypeHandler.java:28)
```
