### PR TITLE
키워드 기반 사용자 경험 검색 api

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -75,6 +75,15 @@ include::{snippets}/record/get-record-by-recordId/path-parameters.adoc[]
 include::{snippets}/record/get-record-by-recordId/http-response.adoc[]
 include::{snippets}/record/get-record-by-recordId/response-fields.adoc[]
 
+==== 특정 사용자의 키워드 기반 경험기록 검색
+===== Request
+include::{snippets}/record/get-records-filter-by-condition/http-request.adoc[]
+include::{snippets}/record/get-records-filter-by-condition/request-parameters.adoc[]
+
+===== Response
+include::{snippets}/record/get-records-filter-by-condition/http-response.adoc[]
+include::{snippets}/record/get-records-filter-by-condition/response-fields.adoc[]
+
 == 4. 전통주 조회
 ==== 전통주 검색
 ===== Request

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -4,10 +4,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import sullog.backend.alcohol.dto.response.AlcoholInfoDto;
+import sullog.backend.alcohol.dto.response.PagingInfoDto;
 import sullog.backend.alcohol.service.AlcoholService;
 import sullog.backend.record.dto.RecordSaveRequestDto;
+import sullog.backend.record.dto.request.RecordSearchParamDto;
 import sullog.backend.record.dto.response.RecordMetaDto;
 import sullog.backend.record.dto.response.RecordDetailDto;
+import sullog.backend.record.dto.response.RecordMetaListWithPagingDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
 import sullog.backend.record.service.ImageUploadService;
@@ -54,6 +57,18 @@ public class RecordController {
         return RecordDetailDto.builder()
                 .record(record)
                 .alcoholInfo(alcoholWithBrand)
+                .build();
+    }
+
+    @GetMapping("/records/search")
+    public RecordMetaListWithPagingDto searchRecords(RecordSearchParamDto recordSearchParamDto) {
+        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByCondition(recordSearchParamDto);
+        return RecordMetaListWithPagingDto.builder()
+                .recordMetaList(recordMetaWithAlcoholInfoList.stream().map(RecordMetaWithAlcoholInfoDto::toResponseDto).collect(Collectors.toList()))
+                .pagingInfo(PagingInfoDto.builder()
+                        .cursor(recordMetaWithAlcoholInfoList.get(recordMetaWithAlcoholInfoList.size() - 1).getRecordId())
+                        .limit(recordSearchParamDto.getLimit())
+                        .build())
                 .build();
     }
 }

--- a/backend/src/main/java/sullog/backend/record/dto/request/RecordSearchParamDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/request/RecordSearchParamDto.java
@@ -1,0 +1,28 @@
+package sullog.backend.record.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public class RecordSearchParamDto {
+
+    private Integer memberId;
+    private String keyword;
+    private Integer cursor;
+    private Integer limit;
+
+    public Integer getMemberId() {
+        return memberId;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+
+    public Integer getCursor() {
+        return cursor;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaListWithPagingDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaListWithPagingDto.java
@@ -1,0 +1,20 @@
+package sullog.backend.record.dto.response;
+
+import lombok.Builder;
+import sullog.backend.alcohol.dto.response.PagingInfoDto;
+
+import java.util.List;
+
+@Builder
+public class RecordMetaListWithPagingDto {
+    private List<RecordMetaDto> recordMetaList;
+    private PagingInfoDto pagingInfo;
+
+    public List<RecordMetaDto> getRecordMetaList() {
+        return recordMetaList;
+    }
+
+    public PagingInfoDto getPagingInfo() {
+        return pagingInfo;
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
@@ -1,6 +1,7 @@
 package sullog.backend.record.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import sullog.backend.record.dto.request.RecordSearchParamDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
 
@@ -14,4 +15,6 @@ public interface RecordMapper {
     List<RecordMetaWithAlcoholInfoDto> selectRecordMetaByMemberId(int memberId);
 
     Record selectRecordById(int recordId);
+
+    List<RecordMetaWithAlcoholInfoDto> selectRecordMetaByCondition(RecordSearchParamDto recordSearchParamDto);
 }

--- a/backend/src/main/java/sullog/backend/record/service/RecordService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordService.java
@@ -1,6 +1,7 @@
 package sullog.backend.record.service;
 
 import org.springframework.stereotype.Service;
+import sullog.backend.record.dto.request.RecordSearchParamDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
 import sullog.backend.record.mapper.RecordMapper;
@@ -27,5 +28,10 @@ public class RecordService {
 
     public Record getRecordByRecordId(int recordId) {
         return recordMapper.selectRecordById(recordId);
+    }
+
+    public List<RecordMetaWithAlcoholInfoDto> getRecordMetasByCondition(RecordSearchParamDto recordSearchParamDto) {
+        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoDtos = recordMapper.selectRecordMetaByCondition(recordSearchParamDto);
+        return recordMetaWithAlcoholInfoDtos;
     }
 }

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -67,9 +67,9 @@
                           production_longitude,
                           alcohol_tag
                     FROM alcohol) AS a
-        ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
+            ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
         LEFT JOIN alcohol_brand AS ab
-        ON a.brand_id = ab.brand_id
+            ON a.brand_id = ab.brand_id
     </select>
 
     <resultMap id="Record" type="sullog.backend.record.entity.Record">
@@ -102,5 +102,44 @@
                experience_date
         FROM record
         WHERE record_id = #{recordId}
+    </select>
+
+    <select id="selectRecordMetaByCondition" resultMap="RecordMetaWithAlcoholInfo">
+        SELECT  r.record_id            AS record_id,
+                r.description          AS description,
+                r.photo_path           AS photo_path,
+                a.alcohol_id           AS alcohol_id,
+                a.name                 AS alcohol_name,
+                a.production_location  AS production_location,
+                a.production_latitude  AS production_latitude,
+                a.production_longitude AS production_longitude,
+                a.alcohol_tag          AS alcohol_tag,
+                ab.name                AS brand_name
+        FROM record AS r
+        LEFT JOIN (SELECT   alcohol_id,
+                            brand_id,
+                            name,
+                            production_location,
+                            production_latitude,
+                            production_longitude,
+                            alcohol_tag
+                            FROM alcohol) AS a
+            ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
+                <if test="cursor != null">
+                    AND <![CDATA[r.record_id < #{cursor}]]>
+                </if>
+        LEFT JOIN alcohol_brand AS ab
+            ON a.brand_id = ab.brand_id
+        <choose>
+            <when test = "keyword != null">
+                WHERE a.name LIKE CONCAT('%', #{keyword}, '%')
+                    OR ab.name LIKE CONCAT('%', #{keyword}, '%')
+                    OR r.description LIKE CONCAT('%', #{keyword}, '%')
+            </when>
+        </choose>
+        ORDER BY r.record_id DESC
+        <if test="limit != null">
+            LIMIT #{limit}
+        </if>
     </select>
 </mapper>


### PR DESCRIPTION
## 개요
- 키워드 기반 사용자 경험 검색 api

## 작업사항
- 해당 api 컨트롤러, 서비스, 매퍼 레이어 작업

## 변경로직
- N/A

## 기타
1. 브랜드를 알코올테이블에 넣고 반정규화 하는게 더 나았을까..하는 생각이 들었습니다 ㅎㅎ
2. 오프셋 기반 페이징 작성해주신거 잘 참고했습니다!! 저는 최신기록이 id값이 크기때문에 DESC 로 정렬을 해서 괄호 방향이 다릅니다! (크로스 체크 부탁드려요!)
3. 최근 검색어 업데이트 로직은 개발당시 고려를 못했습니다! 이 부분은 다른 pr에서 적용하겠습니다. 리뷰 시 참고부탁드립니다!
