### PR TITLE
rest-docs api 문서 접근 시 jwt인증필터 타지 않도록 수정

### DIFF
--- a/backend/src/main/java/sullog/backend/member/config/SecurityConfig.java
+++ b/backend/src/main/java/sullog/backend/member/config/SecurityConfig.java
@@ -51,7 +51,9 @@ public class SecurityConfig {
                     .and()
                 .authorizeRequests()
                     .antMatchers("/login/oauth2/code/**", //kakao oauth redirect url
-                            "/favicon.ico").permitAll()
+                                 "/favicon.ico",
+                                 "/docs/api-doc.html" // rest-docs 문서 url
+                    ).permitAll()
                     .anyRequest().authenticated()
                     .and()
                 .oauth2Login()


### PR DESCRIPTION
## 개요
- 알파서버 배포 후 테스트하면서, accessToken이 없으니 rest-docs api url로 접근 안됨

## 작업사항
- resr-docs api 문서 접근 시 jwt인증필터 타지 않도록 수정

## 변경로직
- permitAll() 대상에 추가
