### PR TITLE
"api" prefix 제거

### DIFF
--- a/backend/src/main/java/sullog/backend/alcohol/controller/AlcoholController.java
+++ b/backend/src/main/java/sullog/backend/alcohol/controller/AlcoholController.java
@@ -19,7 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/alcohols")
+@RequestMapping("/alcohols")
 public class AlcoholController {
 
     private final AlcoholService alcoholService;

--- a/backend/src/main/java/sullog/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/MemberController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import sullog.backend.member.dto.response.RecentSearchHistoryDto;
 
 @RestController
-@RequestMapping("/api/members")
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;
@@ -27,7 +27,7 @@ public class MemberController {
         return new ResponseEntity<>(memberService.getRecentSearchHistory(memberId), HttpStatus.OK);
     }
 
-    @DeleteMapping("/members/me")
+    @DeleteMapping("/me")
     public void deleteMember(@RequestHeader String authorization) {
         String email = tokenService.getEmail(authorization);
         memberService.deleteMember(email);

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
+@RequestMapping("/records")
 public class RecordController {
 
     private final RecordService recordService;
@@ -32,7 +33,7 @@ public class RecordController {
         this.alcoholService = alcoholService;
     }
 
-    @PostMapping("/records")
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public void saveRecord(
                         @RequestPart(required = false) List<MultipartFile> photoList,
@@ -44,13 +45,13 @@ public class RecordController {
         recordService.saveRecord(requestDto.toEntity(photoPathList));
     }
 
-    @GetMapping("/records")
+    @GetMapping
     public List<RecordMetaDto> getRecords(@RequestParam int memberId) {
         List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByMemberId(memberId);
         return recordMetaWithAlcoholInfoList.stream().map(RecordMetaWithAlcoholInfoDto::toResponseDto).collect(Collectors.toList());
     }
 
-    @GetMapping("/records/{recordId}")
+    @GetMapping("/{recordId}")
     public RecordDetailDto getRecord(@PathVariable int recordId) {
         Record record = recordService.getRecordByRecordId(recordId);
         AlcoholInfoDto alcoholWithBrand = alcoholService.getAlcoholById(record.getAlcoholId());
@@ -60,7 +61,7 @@ public class RecordController {
                 .build();
     }
 
-    @GetMapping("/records/search")
+    @GetMapping("/search")
     public RecordMetaListWithPagingDto searchRecords(RecordSearchParamDto recordSearchParamDto) {
         List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByCondition(recordSearchParamDto);
         return RecordMetaListWithPagingDto.builder()

--- a/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
+++ b/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
@@ -87,7 +87,7 @@ class AlcoholControllerTest {
         when(alcoholService.getAlcoholById(anyInt())).thenReturn(alcoholInfoDto);
 
         mockMvc.perform(
-                        get("/api/alcohols")
+                        get("/alcohols")
                                 .param("alcoholId", "1")
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
@@ -147,7 +147,7 @@ class AlcoholControllerTest {
         when(alcoholService.getAlcoholInfo(email, alcoholSearchRequestDto)).thenReturn(alcoholInfoWithPagingDto);
 
         mockMvc.perform(
-                        get("/api/alcohols/search")
+                        get("/alcohols/search")
                                 .queryParam("keyword", alcoholSearchRequestDto.getKeyword())
                                 .queryParam("cursor", String.valueOf(alcoholSearchRequestDto.getCursor()))
                                 .queryParam("limit", String.valueOf(alcoholSearchRequestDto.getLimit()))

--- a/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
@@ -73,7 +73,7 @@ class MemberControllerTest {
         doNothing().when(memberService).deleteMember(email);
 
         // then
-        this.mockMvc.perform(delete("/api/members/members/me")
+        this.mockMvc.perform(delete("/members/me")
                         .header(HttpHeaders.AUTHORIZATION, accessToken))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
@@ -93,7 +93,7 @@ class MemberControllerTest {
         when(memberService.getRecentSearchHistory(anyInt())).thenReturn(recentSearchHistoryDto);
 
         mockMvc.perform(
-                        get("/api/members/{memberId}/recent-search-history", 1)
+                        get("/members/{memberId}/recent-search-history", 1)
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 개요
- [클라이언트에서 prefix 상관없다고](https://www.notion.so/0-42ec0b5127c641d5977d344f57df3bc6?d=614494d3dac64e0ab5c466eb499def29) 하셔서, api path 정비했습니다!

## 작업사항
- API path 재정비

## 변경로직
- "api" prefix 제거
- 회원탈퇴 api에서 컨트롤러 상단과 메서드에서 path가 중복되는 부분 일원화
- 관련 tc 수정