### PR TITLE
restdocs adoc 문서 구성 수정

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -28,7 +28,7 @@
 | `TBD`
 |===
 
-== 1. 인증
+== 1. 사용자
 === 카카오 로그인 요청
 카카오 인증 서버와 통신하며 인가코드를 전달받고, 인가코드 기반으로 회원가입 or 로그인 프로세스를 진행.
 
@@ -48,7 +48,6 @@ include::{snippets}/token-refresh/http-request.adoc[]
 include::{snippets}/token-refresh/http-response.adoc[]
 include::{snippets}/token-refresh/response-headers.adoc[]
 
-== 2. 사용자
 === 최근 검색어 조회
 ==== Request
 include::{snippets}/member-get-recent-search/http-request.adoc[]
@@ -65,7 +64,7 @@ include::{snippets}/member/delete-member/request-headers.adoc[]
 ==== Response
 include::{snippets}/member/delete-member/http-response.adoc[]
 
-== 3. 전통주
+== 2. 전통주
 === 키워드 기반 전통주 검색
 ==== Request
 include::{snippets}/alcohol-search/http-request.adoc[]

--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -3,8 +3,18 @@
 :toclevels: 2
 :source-highlighter: highlightjs
 
-== 1. 개요
+== 개요
 술로그 서비스 API 명세입니다.
+
+=== 버전
+|===
+|날짜 | 버전 | 배포 히스토리
+
+|2023-03-05
+| v0
+| https://www.notion.so/shinwonse/0-42ec0b5127c641d5977d344f57df3bc6
+
+|===
 
 === Domain
 
@@ -18,7 +28,7 @@
 | `TBD`
 |===
 
-== 2. 인증
+== 1. 인증
 === 카카오 로그인 요청
 카카오 인증 서버와 통신하며 인가코드를 전달받고, 인가코드 기반으로 회원가입 or 로그인 프로세스를 진행.
 
@@ -38,6 +48,14 @@ include::{snippets}/token-refresh/http-request.adoc[]
 include::{snippets}/token-refresh/http-response.adoc[]
 include::{snippets}/token-refresh/response-headers.adoc[]
 
+== 2. 사용자
+=== 최근 검색어 조회
+==== Request
+include::{snippets}/member-get-recent-search/http-request.adoc[]
+include::{snippets}/member-get-recent-search/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/member-get-recent-search/http-response.adoc[]
 
 === 회원 탈퇴
 ==== Request
@@ -46,6 +64,24 @@ include::{snippets}/member/delete-member/request-headers.adoc[]
 
 ==== Response
 include::{snippets}/member/delete-member/http-response.adoc[]
+
+== 3. 전통주
+=== 키워드 기반 전통주 검색
+==== Request
+include::{snippets}/alcohol-search/http-request.adoc[]
+include::{snippets}/alcohol-search/request-parameters.adoc[]
+
+==== Response
+include::{snippets}/alcohol-search/http-response.adoc[]
+
+
+=== 전통주 id기반 전통주 단건 조회
+==== Request
+include::{snippets}/alcohol-get/http-request.adoc[]
+include::{snippets}/alcohol-get/request-parameters.adoc[]
+
+==== Response
+include::{snippets}/alcohol-get/http-response.adoc[]
 
 == 3. 전통주 경험
 === 전통주 경험 저장
@@ -57,7 +93,7 @@ include::{snippets}/record/save-record/request-part-recordInfo-fields.adoc[]
 ==== Response
 include::{snippets}/record/save-record/http-response.adoc[]
 
-==== 특정 사용자의 전통주 경험 조회
+=== 특정 사용자의 전통주 경험 조회
 ===== Request
 include::{snippets}/record/get-records-by-memberId/http-request.adoc[]
 include::{snippets}/record/get-records-by-memberId/request-parameters.adoc[]
@@ -66,7 +102,7 @@ include::{snippets}/record/get-records-by-memberId/request-parameters.adoc[]
 include::{snippets}/record/get-records-by-memberId/http-response.adoc[]
 include::{snippets}/record/get-records-by-memberId/response-fields.adoc[]
 
-==== 경험기록 id 기반 전통주 경험 단건 조회
+=== 경험기록 id 기반 전통주 경험 단건 조회
 ===== Request
 include::{snippets}/record/get-record-by-recordId/http-request.adoc[]
 include::{snippets}/record/get-record-by-recordId/path-parameters.adoc[]
@@ -75,7 +111,7 @@ include::{snippets}/record/get-record-by-recordId/path-parameters.adoc[]
 include::{snippets}/record/get-record-by-recordId/http-response.adoc[]
 include::{snippets}/record/get-record-by-recordId/response-fields.adoc[]
 
-==== 특정 사용자의 키워드 기반 경험기록 검색
+=== 특정 사용자의 키워드 기반 경험기록 검색
 ===== Request
 include::{snippets}/record/get-records-filter-by-condition/http-request.adoc[]
 include::{snippets}/record/get-records-filter-by-condition/request-parameters.adoc[]
@@ -84,30 +120,3 @@ include::{snippets}/record/get-records-filter-by-condition/request-parameters.ad
 include::{snippets}/record/get-records-filter-by-condition/http-response.adoc[]
 include::{snippets}/record/get-records-filter-by-condition/response-fields.adoc[]
 
-== 4. 전통주 조회
-=== 전통주 검색
-==== Request
-include::{snippets}/alcohol-search/http-request.adoc[]
-include::{snippets}/alcohol-search/request-parameters.adoc[]
-
-==== Response
-include::{snippets}/alcohol-search/http-response.adoc[]
-
-
-=== 전통주 조회
-==== Request
-include::{snippets}/alcohol-get/http-request.adoc[]
-include::{snippets}/alcohol-get/request-parameters.adoc[]
-
-==== Response
-include::{snippets}/alcohol-get/http-response.adoc[]
-
-
-== 5. 최근 검색어
-=== 최근 검색어 조회
-==== Request
-include::{snippets}/member-get-recent-search/http-request.adoc[]
-include::{snippets}/member-get-recent-search/path-parameters.adoc[]
-
-==== Response
-include::{snippets}/member-get-recent-search/http-response.adoc[]


### PR DESCRIPTION
## 개요
- restdocs api 문서 구성 수정(#39)

## 작업사항
- api 버전 관련 내용 `개요`에 추가
- 도메인별로 api 구조화
  - 도메인을 제목으로하고, 하위에 api 내용 명세

### 예시
![image](https://user-images.githubusercontent.com/48347010/224550275-74e9bb10-872b-419d-b420-26b23a7667f6.png)

## 참고
저는 도메인별로 묶는게 깔끔할 것 같아서, 이렇게 수정하였는데 혹씨 별로시면 의견부탁드립니다!! 
 