### PR TITLE
healthcheck 요청처리 api 분리

### DIFF
--- a/backend/src/main/java/sullog/backend/common/controller/HealthCheckController.java
+++ b/backend/src/main/java/sullog/backend/common/controller/HealthCheckController.java
@@ -1,0 +1,15 @@
+package sullog.backend.common.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/")
+    @ResponseStatus(value = HttpStatus.OK, code = HttpStatus.OK)
+    public void healthCheck() {
+    }
+}

--- a/backend/src/main/java/sullog/backend/member/config/SecurityConfig.java
+++ b/backend/src/main/java/sullog/backend/member/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
                 .authorizeRequests()
                     .antMatchers("/login/oauth2/code/**", //kakao oauth redirect url
                                  "/favicon.ico",
-                                 "/docs/api-doc.html" // rest-docs 문서 url
+                                 "/docs/api-doc.html", // rest-docs 문서 url
+                                 "/" //health-check end point
                     ).permitAll()
                     .anyRequest().authenticated()
                     .and()

--- a/backend/src/main/java/sullog/backend/member/config/jwt/JwtAuthFilter.java
+++ b/backend/src/main/java/sullog/backend/member/config/jwt/JwtAuthFilter.java
@@ -26,7 +26,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-        if (isRootContext(httpServletRequest)) return;
         String token = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (tokenService.validateToken(token)) { // JWT 토큰이 유효한 경우에만, USER객체 셋팅
@@ -34,13 +33,5 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         filterChain.doFilter(servletRequest, servletResponse); // 다음 Filter를 실행(마지막 필터라면 필터 실행 후 리소스를 반환)
-    }
-
-    /**
-     * AWS 에서 서버 health check를 하게 되는데 default가 /로 체크를 해 해당 메소드가 없다면 401 에러가 나게됨
-     * 추후 health check 전용 컨텍스트를 만들던지 현행 유지
-     */
-    private static boolean isRootContext(HttpServletRequest httpServletRequest) {
-        return httpServletRequest.getRequestURI().equals("/");
     }
 }

--- a/backend/src/main/java/sullog/backend/member/controller/AuthController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/AuthController.java
@@ -1,10 +1,7 @@
 package sullog.backend.member.controller;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import sullog.backend.member.entity.Token;
 import sullog.backend.member.service.TokenService;
@@ -29,10 +26,5 @@ public class AuthController {
 
         response.addHeader(HttpHeaders.AUTHORIZATION, newToken.getAccessToken());
         response.addHeader("Refresh", newToken.getRefreshToken());
-    }
-
-    @GetMapping("/")
-    @ResponseStatus(value = HttpStatus.OK, code = HttpStatus.OK)
-    public void checkNetwork() {
     }
 }


### PR DESCRIPTION
## 개요
- 작업배경: #42 

## 작업사항
- health check 관련 로직 분리

## 변경로직
- controller 로직을 auth -> 새로운 컨트롤러로 분리
- jwtauthfilter에서 path로 분기처리하는 로직을 spring security에서 처리하도록 수정
