### PR TITLE
SpringSecurityConfig에 명시적으로 cors(), 관련 설정 bean 추가

### DIFF
--- a/backend/src/main/java/sullog/backend/member/config/SecurityConfig.java
+++ b/backend/src/main/java/sullog/backend/member/config/SecurityConfig.java
@@ -39,6 +39,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
+                .cors()
+                .and()
                 .httpBasic().disable()
                 .csrf().disable() // Rest API 서버이기때문에 CSRF 처리를 해제
                 .formLogin().disable()

--- a/backend/src/main/java/sullog/backend/member/config/oauth/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/sullog/backend/member/config/oauth/OAuth2SuccessHandler.java
@@ -10,7 +10,6 @@ import sullog.backend.member.dto.MemberDto;
 import sullog.backend.member.entity.Token;
 import sullog.backend.member.service.TokenService;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;


### PR DESCRIPTION
## 개요
- #56 일부 반영
- [cors이슈 노션 정리 > 예상이슈3번](https://www.notion.so/shinwonse/CORS-3d30a7490e9849608dfc365a72716c8c) 대응 (cors 이슈 해결 예정)

## 작업사항
- 스프링 시큐리티 설정에 cors() 옵션 명시적으로 주기
- 관련 configuration 로직 추가(노션에 추가해주셨던 WebConfig 로직 적용)

## 변경로직
- N/A

## 참고
- as-is: ![image](https://user-images.githubusercontent.com/48347010/226171039-20771f12-e091-410b-b555-bbe5ce5c55e9.png)
- to-be: ![image](https://user-images.githubusercontent.com/48347010/226171096-d55907c2-7b81-4426-a775-ab8b8be82b0c.png)

