### PR TITLE
path나 queryparameter로 memberId전달받는 api는 me로 변경

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -95,7 +95,6 @@ include::{snippets}/record/save-record/http-response.adoc[]
 === 특정 사용자의 전통주 경험 조회
 ===== Request
 include::{snippets}/record/get-records-by-memberId/http-request.adoc[]
-include::{snippets}/record/get-records-by-memberId/request-parameters.adoc[]
 
 ===== Response
 include::{snippets}/record/get-records-by-memberId/http-response.adoc[]

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -38,14 +38,17 @@ public class RecordController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void saveRecord(
+    public void saveRecord(@RequestHeader(name="Authorization") String accessToken,
                         @RequestPart(required = false) List<MultipartFile> photoList,
                         @RequestPart("recordInfo") RecordSaveRequestDto requestDto) {
+        // 작성자 조회
+        int memberId = tokenService.getMemberId(accessToken);
+
         // 이미지 저장
         List<String> photoPathList = imageUploadService.uploadImageList(photoList);
 
         // 경험기록 저장
-        recordService.saveRecord(requestDto.toEntity(photoPathList));
+        recordService.saveRecord(requestDto.toEntity(memberId, photoPathList));
     }
 
     @GetMapping("/me")

--- a/backend/src/main/java/sullog/backend/record/dto/RecordSaveRequestDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/RecordSaveRequestDto.java
@@ -10,9 +10,6 @@ import java.util.List;
 
 @Builder
 public class RecordSaveRequestDto {
-
-    private Integer memberId; // 작성자 id
-
     private Integer alcoholId; // 술 id
 
     private String title; // 제목
@@ -35,7 +32,6 @@ public class RecordSaveRequestDto {
     }
 
     public RecordSaveRequestDto(
-            Integer memberId,
             Integer alcoholId,
             String title,
             AlcoholPercentFeeling alcoholPercentFeeling,
@@ -45,7 +41,6 @@ public class RecordSaveRequestDto {
             Integer textureScore,
             String description,
             LocalDate experienceDate) {
-        this.memberId = memberId;
         this.alcoholId = alcoholId;
         this.title = title;
         this.alcoholPercentFeeling = alcoholPercentFeeling;
@@ -55,10 +50,6 @@ public class RecordSaveRequestDto {
         this.textureScore = textureScore;
         this.description = description;
         this.experienceDate = experienceDate;
-    }
-
-    public int getMemberId() {
-        return memberId;
     }
 
     public int getAlcoholId() {
@@ -97,7 +88,7 @@ public class RecordSaveRequestDto {
         return experienceDate;
     }
 
-    public Record toEntity(List<String> photoPathList) {
+    public Record toEntity(int memberId, List<String> photoPathList) {
         return Record.builder()
                 .memberId(memberId)
                 .alcoholId(alcoholId)

--- a/backend/src/main/java/sullog/backend/record/dto/request/RecordSearchParamDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/request/RecordSearchParamDto.java
@@ -5,14 +5,9 @@ import lombok.Builder;
 @Builder
 public class RecordSearchParamDto {
 
-    private Integer memberId;
     private String keyword;
     private Integer cursor;
     private Integer limit;
-
-    public Integer getMemberId() {
-        return memberId;
-    }
 
     public String getKeyword() {
         return keyword;

--- a/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
@@ -1,6 +1,7 @@
 package sullog.backend.record.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import sullog.backend.record.dto.request.RecordSearchParamDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
@@ -16,5 +17,6 @@ public interface RecordMapper {
 
     Record selectRecordById(int recordId);
 
-    List<RecordMetaWithAlcoholInfoDto> selectRecordMetaByCondition(RecordSearchParamDto recordSearchParamDto);
+    List<RecordMetaWithAlcoholInfoDto> selectRecordMetaByCondition(@Param("memberId") int memberId,
+                                                                   @Param("recordSearchParamDto") RecordSearchParamDto recordSearchParamDto);
 }

--- a/backend/src/main/java/sullog/backend/record/service/RecordService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordService.java
@@ -30,8 +30,8 @@ public class RecordService {
         return recordMapper.selectRecordById(recordId);
     }
 
-    public List<RecordMetaWithAlcoholInfoDto> getRecordMetasByCondition(RecordSearchParamDto recordSearchParamDto) {
-        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoDtos = recordMapper.selectRecordMetaByCondition(recordSearchParamDto);
+    public List<RecordMetaWithAlcoholInfoDto> getRecordMetasByCondition(int memberId, RecordSearchParamDto recordSearchParamDto) {
+        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoDtos = recordMapper.selectRecordMetaByCondition(memberId, recordSearchParamDto);
         return recordMetaWithAlcoholInfoDtos;
     }
 }

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -125,21 +125,21 @@
                             alcohol_tag
                             FROM alcohol) AS a
             ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
-                <if test="cursor != null">
-                    AND <![CDATA[r.record_id < #{cursor}]]>
+                <if test="recordSearchParamDto.cursor != null">
+                    AND <![CDATA[r.record_id < #{recordSearchParamDto.cursor}]]>
                 </if>
         LEFT JOIN alcohol_brand AS ab
             ON a.brand_id = ab.brand_id
         <choose>
-            <when test = "keyword != null">
-                WHERE a.name LIKE CONCAT('%', #{keyword}, '%')
-                    OR ab.name LIKE CONCAT('%', #{keyword}, '%')
-                    OR r.description LIKE CONCAT('%', #{keyword}, '%')
+            <when test = "recordSearchParamDto.keyword != null">
+                WHERE a.name LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%')
+                    OR ab.name LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%')
+                    OR r.description LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%')
             </when>
         </choose>
         ORDER BY r.record_id DESC
-        <if test="limit != null">
-            LIMIT #{limit}
+        <if test="recordSearchParamDto.limit != null">
+            LIMIT #{recordSearchParamDto.limit}
         </if>
     </select>
 </mapper>

--- a/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
+++ b/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
@@ -142,9 +142,9 @@ class AlcoholControllerTest {
                 .limit(1)
                 .build();
 
-        String email = "sampel@naver.com";
-        when(tokenService.getEmail(anyString())).thenReturn(email);
-        when(alcoholService.getAlcoholInfo(email, alcoholSearchRequestDto)).thenReturn(alcoholInfoWithPagingDto);
+        int memberId = 1;
+        when(tokenService.getMemberId(anyString())).thenReturn(memberId);
+        when(alcoholService.getAlcoholInfo(memberId, alcoholSearchRequestDto)).thenReturn(alcoholInfoWithPagingDto);
 
         mockMvc.perform(
                         get("/alcohols/search")
@@ -152,7 +152,7 @@ class AlcoholControllerTest {
                                 .queryParam("cursor", String.valueOf(alcoholSearchRequestDto.getCursor()))
                                 .queryParam("limit", String.valueOf(alcoholSearchRequestDto.getLimit()))
                                 .with(request -> {
-                                    request.addHeader("Authorization", "auth");
+                                    request.addHeader("Authorization", "accessToken");
                                     return request;
                                 })
                 )


### PR DESCRIPTION
## 개요
- #55 

## 작업사항
- accessToken기반으로 memberId 추출해서, 기존에 memberId 적용했던 곳 대체

## 변경로직
- as-is: memberId 필요시 클라이언트로부터 전달받음
- to-be: accessToken 기반으로 memberId 추출

## 기타
특정 사용자에 종속된 로직은 그러면, accessToken 기반으로 memberId를 찾는 로직이 무조건 들어가게 될텐데, 이 부분을 interceptor로 추출하는건 어떨지?! 생각이들었습니당
