### PR TITLE
[feat] 기록 피드 API

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -118,6 +118,16 @@ include::{snippets}/record/get-records-filter-by-condition/request-parameters.ad
 include::{snippets}/record/get-records-filter-by-condition/http-response.adoc[]
 include::{snippets}/record/get-records-filter-by-condition/response-fields.adoc[]
 
+
+=== 경험 피드
+===== Request
+include::{snippets}/record/get-record-feeds/http-request.adoc[]
+include::{snippets}/record/get-record-feeds/request-parameters.adoc[]
+
+===== Response
+include::{snippets}/record/get-record-feeds/http-response.adoc[]
+include::{snippets}/record/get-record-feeds/response-fields.adoc[]
+
 == 4. 별첨
 === alcoholPercentFeeling
 

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -1,6 +1,7 @@
 package sullog.backend.record.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import sullog.backend.alcohol.dto.response.AlcoholInfoDto;
@@ -9,9 +10,8 @@ import sullog.backend.alcohol.service.AlcoholService;
 import sullog.backend.member.service.TokenService;
 import sullog.backend.record.dto.RecordSaveRequestDto;
 import sullog.backend.record.dto.request.RecordSearchParamDto;
-import sullog.backend.record.dto.response.RecordMetaDto;
-import sullog.backend.record.dto.response.RecordDetailDto;
-import sullog.backend.record.dto.response.RecordMetaListWithPagingDto;
+import sullog.backend.record.dto.response.*;
+import sullog.backend.record.dto.table.AllRecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
 import sullog.backend.record.service.ImageUploadService;
@@ -79,5 +79,26 @@ public class RecordController {
                         .limit(recordSearchParamDto.getLimit())
                         .build())
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<AllRecordMetaListWithPaging> getRecordFeed(
+            @RequestParam(required = false) Integer cursor,
+            @RequestParam Integer limit) {
+        List<AllRecordMetaWithAlcoholInfoDto> allRecordMetaWithAlcoholInfoList = recordService.getRecordFeed(cursor, limit);
+        int newCursor = 0;
+        if (allRecordMetaWithAlcoholInfoList.size() > 0) {
+            newCursor = allRecordMetaWithAlcoholInfoList.get(allRecordMetaWithAlcoholInfoList.size() - 1).getRecordId();
+        }
+        AllRecordMetaListWithPaging allRecordMetaListWithPaging = AllRecordMetaListWithPaging.builder()
+                .allRecordMetaList(allRecordMetaWithAlcoholInfoList.stream()
+                        .map(AllRecordMetaWithAlcoholInfoDto::toResponseDto)
+                        .collect(Collectors.toList()))
+                .pagingInfo(PagingInfoDto.builder()
+                        .cursor(newCursor)
+                        .limit(limit)
+                        .build())
+                .build();
+        return new ResponseEntity<>(allRecordMetaListWithPaging, HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/sullog/backend/record/dto/response/AllRecordMeta.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/AllRecordMeta.java
@@ -1,0 +1,63 @@
+package sullog.backend.record.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class AllRecordMeta {
+    
+    private Integer memberId; // 유저 id
+    private Integer recordId; // 경험기록 id
+    private String description; // 경험기록 상세내용
+    private String mainPhotoPath; // 사용자가 등록한 사진 경로(optional)
+    private Integer alcoholId; // 전통주 id
+    private String alcoholName; // 전통주 이름
+    private String productionLocation; // 생산지 명
+    private Double productionLatitude; // 전통주 생산지 위도
+    private Double productionLongitude; // 전통주 생산지 경도
+    private String alcoholTag; // 전통주 태그
+    private String brandName; // 브랜드 이름
+
+    public Integer getMemberId() {
+        return memberId;
+    }
+
+    public Integer getRecordId() {
+        return recordId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getMainPhotoPath() {
+        return mainPhotoPath;
+    }
+
+    public Integer getAlcoholId() {
+        return alcoholId;
+    }
+
+    public String getAlcoholName() {
+        return alcoholName;
+    }
+
+    public String getProductionLocation() {
+        return productionLocation;
+    }
+
+    public Double getProductionLatitude() {
+        return productionLatitude;
+    }
+
+    public Double getProductionLongitude() {
+        return productionLongitude;
+    }
+
+    public String getAlcoholTag() {
+        return alcoholTag;
+    }
+
+    public String getBrandName() {
+        return brandName;
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/dto/response/AllRecordMetaListWithPaging.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/AllRecordMetaListWithPaging.java
@@ -1,0 +1,20 @@
+package sullog.backend.record.dto.response;
+
+import lombok.Builder;
+import sullog.backend.alcohol.dto.response.PagingInfoDto;
+
+import java.util.List;
+
+@Builder
+public class AllRecordMetaListWithPaging {
+    private List<AllRecordMeta> allRecordMetaList;
+    private PagingInfoDto pagingInfo;
+
+    public List<AllRecordMeta> getAllRecordMetaList() {
+        return allRecordMetaList;
+    }
+
+    public PagingInfoDto getPagingInfo() {
+        return pagingInfo;
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/dto/table/AllRecordMetaWithAlcoholInfoDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/table/AllRecordMetaWithAlcoholInfoDto.java
@@ -1,0 +1,117 @@
+package sullog.backend.record.dto.table;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import sullog.backend.record.dto.response.AllRecordMeta;
+
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+public class AllRecordMetaWithAlcoholInfoDto {
+
+    private Integer memberId;
+    private Integer recordId;
+    private String description;
+    private List<String> photoPathList;
+    private Integer alcoholId;
+    private String alcoholName;
+    private String productionLocation;
+    private Double productionLatitude;
+    private Double productionLongitude;
+    private String alcoholTag;
+    private String brandName;
+
+    public Integer getMemberId() {
+        return memberId;
+    }
+
+    public String getBrandName() {
+        return brandName;
+    }
+
+    public Integer getRecordId() {
+        return recordId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<String> getPhotoPathList() {
+        return photoPathList;
+    }
+
+    public Integer getAlcoholId() {
+        return alcoholId;
+    }
+
+    public String getAlcoholName() {
+        return alcoholName;
+    }
+
+    public String getProductionLocation() {
+        return productionLocation;
+    }
+
+    public Double getProductionLatitude() {
+        return productionLatitude;
+    }
+
+    public Double getProductionLongitude() {
+        return productionLongitude;
+    }
+
+    public String getAlcoholTag() {
+        return alcoholTag;
+    }
+
+    public AllRecordMetaWithAlcoholInfoDto(
+            Integer memberId,
+            Integer recordId,
+            String description,
+            List<String> photoPathList,
+            Integer alcoholId,
+            String alcoholName,
+            String productionLocation,
+            Double productionLatitude,
+            Double productionLongitude,
+            String alcoholTag,
+            String brandName) {
+        this.memberId = memberId;
+        this.recordId = recordId;
+        this.description = description;
+        this.photoPathList = photoPathList;
+        this.alcoholId = alcoholId;
+        this.alcoholName = alcoholName;
+        this.productionLocation = productionLocation;
+        this.productionLatitude = productionLatitude;
+        this.productionLongitude = productionLongitude;
+        this.alcoholTag = alcoholTag;
+        this.brandName = brandName;
+    }
+
+    public AllRecordMeta toResponseDto() {
+        return AllRecordMeta.builder()
+                .memberId(memberId)
+                .recordId(recordId)
+                .description(description)
+                .mainPhotoPath(getMainPhotoPath())
+                .alcoholId(alcoholId)
+                .alcoholName(alcoholName)
+                .productionLocation(productionLocation)
+                .productionLatitude(productionLatitude)
+                .productionLongitude(productionLongitude)
+                .alcoholTag(alcoholTag)
+                .brandName(brandName)
+                .build();
+    }
+
+    private String getMainPhotoPath() {
+        if(photoPathList.isEmpty()) {
+            return "";
+        }
+
+        return photoPathList.get(0);
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/RecordMapper.java
@@ -3,6 +3,7 @@ package sullog.backend.record.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import sullog.backend.record.dto.request.RecordSearchParamDto;
+import sullog.backend.record.dto.table.AllRecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
 
@@ -19,4 +20,6 @@ public interface RecordMapper {
 
     List<RecordMetaWithAlcoholInfoDto> selectRecordMetaByCondition(@Param("memberId") int memberId,
                                                                    @Param("recordSearchParamDto") RecordSearchParamDto recordSearchParamDto);
+
+    List<AllRecordMetaWithAlcoholInfoDto> selectAllRecordMetaByPaging(@Param("recordSearchParamDto") RecordSearchParamDto recordSearchParamDto);
 }

--- a/backend/src/main/java/sullog/backend/record/service/RecordService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordService.java
@@ -1,7 +1,10 @@
 package sullog.backend.record.service;
 
 import org.springframework.stereotype.Service;
+import sullog.backend.member.mapper.MemberMapper;
 import sullog.backend.record.dto.request.RecordSearchParamDto;
+import sullog.backend.record.dto.response.AllRecordMetaListWithPaging;
+import sullog.backend.record.dto.table.AllRecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
 import sullog.backend.record.mapper.RecordMapper;
@@ -33,5 +36,14 @@ public class RecordService {
     public List<RecordMetaWithAlcoholInfoDto> getRecordMetasByCondition(int memberId, RecordSearchParamDto recordSearchParamDto) {
         List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoDtos = recordMapper.selectRecordMetaByCondition(memberId, recordSearchParamDto);
         return recordMetaWithAlcoholInfoDtos;
+    }
+
+    public List<AllRecordMetaWithAlcoholInfoDto> getRecordFeed(Integer cursor, Integer limit) {
+        RecordSearchParamDto recordSearchParamDto = RecordSearchParamDto.builder()
+                .cursor(cursor)
+                .keyword("")
+                .limit(limit)
+                .build();
+        return recordMapper.selectAllRecordMetaByPaging(recordSearchParamDto);
     }
 }

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -142,4 +142,54 @@
             LIMIT #{recordSearchParamDto.limit}
         </if>
     </select>
+
+    <resultMap id="RecordMetaWithAlcoholInfoAndMemberId" type="sullog.backend.record.dto.table.AllRecordMetaWithAlcoholInfoDto">
+        <result property="memberId" column="member_id"/>
+        <result property="recordId" column="record_id"/>
+        <result property="description" column="description"/>
+        <result property="photoPathList" column="photo_path" typeHandler="sullog.backend.common.mapper.typehandler.StringListTypeHandler"/>
+        <result property="alcoholId" column="alcohol_id"/>
+        <result property="alcoholName" column="alcohol_name"/>
+        <result property="productionLocation" column="production_location"/>
+        <result property="productionLatitude" column="production_latitude"/>
+        <result property="productionLongitude" column="production_longitude"/>
+        <result property="alcoholTag" column="alcohol_tag"/>
+        <result property="brandName" column="brand_name"/>
+    </resultMap>
+
+    <select id="selectAllRecordMetaByPaging" resultMap="RecordMetaWithAlcoholInfoAndMemberId">
+        SELECT
+        r.member_id            AS member_id,
+        r.record_id            AS record_id,
+        r.description          AS description,
+        r.photo_path           AS photo_path,
+        a.alcohol_id           AS alcohol_id,
+        a.name                 AS alcohol_name,
+        a.production_location  AS production_location,
+        a.production_latitude  AS production_latitude,
+        a.production_longitude AS production_longitude,
+        a.alcohol_tag          AS alcohol_tag,
+        ab.name                AS brand_name
+        FROM record AS r
+        LEFT JOIN (
+            SELECT alcohol_id,
+                    brand_id,
+                    name,
+                    production_location,
+                    production_latitude,
+                    production_longitude,
+                    alcohol_tag
+            FROM alcohol
+        ) AS a
+        ON r.alcohol_id = a.alcohol_id
+        <if test="recordSearchParamDto.cursor != null">
+            AND <![CDATA[r.record_id < #{recordSearchParamDto.cursor}]]>
+        </if>
+        LEFT JOIN alcohol_brand AS ab
+        ON a.brand_id = ab.brand_id
+        ORDER BY r.record_id DESC
+        <if test="recordSearchParamDto.limit != null">
+            LIMIT #{recordSearchParamDto.limit}
+        </if>
+    </select>
 </mapper>


### PR DESCRIPTION
## 개요
- 기록 피드 API 구현

## 작업사항
- 인스타그램 피드처럼 다른 사람들의 피드를 볼 수 있도록 불특정 다수의 record를 조회하는 API
- 현재는 최신 시간순으로 정렬되도록 함
- 페이징 적용

## 기타
- 추후 요청에 따라 정렬 조건을 바꾸는 것도 고려
