### PR TITLE
테이블 조인 시 on에 설정했던 조건들을 where로 옮김

### DIFF
--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -67,9 +67,10 @@
                           production_longitude,
                           alcohol_tag
                     FROM alcohol) AS a
-            ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
+            ON r.alcohol_id = a.alcohol_id
         LEFT JOIN alcohol_brand AS ab
             ON a.brand_id = ab.brand_id
+        WHERE r.member_id = #{memberId}
     </select>
 
     <resultMap id="Record" type="sullog.backend.record.entity.Record">
@@ -124,17 +125,18 @@
                             production_longitude,
                             alcohol_tag
                             FROM alcohol) AS a
-            ON r.alcohol_id = a.alcohol_id AND r.member_id = #{memberId}
-                <if test="recordSearchParamDto.cursor != null">
-                    AND <![CDATA[r.record_id < #{recordSearchParamDto.cursor}]]>
-                </if>
+            ON r.alcohol_id = a.alcohol_id
         LEFT JOIN alcohol_brand AS ab
             ON a.brand_id = ab.brand_id
+        WHERE r.member_id = #{memberId}
+        <if test="recordSearchParamDto.cursor != null">
+            AND <![CDATA[r.record_id < #{recordSearchParamDto.cursor}]]>
+        </if>
         <choose>
             <when test = "recordSearchParamDto.keyword != null">
-                WHERE a.name LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%')
+            AND (a.name LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%')
                     OR ab.name LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%')
-                    OR r.description LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%')
+                    OR r.description LIKE CONCAT('%', #{recordSearchParamDto.keyword}, '%'))
             </when>
         </choose>
         ORDER BY r.record_id DESC
@@ -182,11 +184,11 @@
             FROM alcohol
         ) AS a
         ON r.alcohol_id = a.alcohol_id
-        <if test="recordSearchParamDto.cursor != null">
-            AND <![CDATA[r.record_id < #{recordSearchParamDto.cursor}]]>
-        </if>
         LEFT JOIN alcohol_brand AS ab
         ON a.brand_id = ab.brand_id
+        <if test="recordSearchParamDto.cursor != null">
+            WHERE <![CDATA[r.record_id < #{recordSearchParamDto.cursor}]]>
+        </if>
         ORDER BY r.record_id DESC
         <if test="recordSearchParamDto.limit != null">
             LIMIT #{recordSearchParamDto.limit}


### PR DESCRIPTION
## 개요
- on에 조건을 주려면, right table 기준으로만 가능해서 수정
- 참고: https://stackoverflow.com/questions/354070/sql-join-where-clause-vs-on-clause 

## 작업사항
- sql query에서 on에 주었던 조건들을 where절로 옮김

## 변경로직
- as-is: ON member_id = 3
- to-be: WHERE member_id =3
