### PR TITLE
경험 저장 api 에서 첨부파일이 없을 경우를 검사하는 조건문 수정

### DIFF
--- a/backend/src/main/java/sullog/backend/record/service/ImageUploadServiceAwsImpl.java
+++ b/backend/src/main/java/sullog/backend/record/service/ImageUploadServiceAwsImpl.java
@@ -46,7 +46,7 @@ public class ImageUploadServiceAwsImpl implements ImageUploadService{
     }
 
     public List<String> uploadImageList(List<MultipartFile> multipartFileList) {
-        if(multipartFileList.isEmpty()) {
+        if(null == multipartFileList) {
             return Collections.emptyList();
         }
 


### PR DESCRIPTION
## 개요
- as-is 로직에서는 첨부파일이 없을 경우, multipartFileList 객체가 null 이어서 객체의 isEmpty를 호출하면 npe 발생

## 작업사항
- 첨부파일이 없는 경우를 검사하는 조건문을 npe safe하게 수정

## 변경로직
- as-is: 객체.isEmpty() 로 검사
- to-be: null == 객체 << 방식으로 검사