### PR TITLE
Access-Control-Expose-Headers 설정 추가

### DIFF
--- a/backend/src/main/java/sullog/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package sullog.backend.common.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -20,6 +21,7 @@ import sullog.backend.member.service.CustomOAuth2UserService;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 @EnableWebSecurity
 public class SecurityConfig {
@@ -87,6 +89,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Collections.singletonList(frontDomain));
         configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE","OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setExposedHeaders(List.of("Refresh", HttpHeaders.AUTHORIZATION));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;


### PR DESCRIPTION
## 개요
- 클라이언트에서 등록한 이슈 #68 

## 작업사항
- 클라이언트에서 jwt토큰 헤더 접근할 수 있도록 Access-Control-Expose-Headers 설정 추가

## 변경로직
- as-is: Nothing
- to-be: Access-Control-Expose-Headers 설정 추가
