### PR TITLE
회원가입 시 최근검색어 필드의 기본값이 []이 되도록 수정

### DIFF
--- a/backend/src/main/java/sullog/backend/auth/service/KakaoService.java
+++ b/backend/src/main/java/sullog/backend/auth/service/KakaoService.java
@@ -84,9 +84,6 @@ public class KakaoService {
         String nickName = jsonNode.get("properties")
                 .get("nickname").asText();
 
-        return Member.builder()
-                .email(email)
-                .nickName(nickName)
-                .build();
+        return Member.ofRegisterMember(email, nickName);
     }
 }

--- a/backend/src/main/java/sullog/backend/member/entity/Member.java
+++ b/backend/src/main/java/sullog/backend/member/entity/Member.java
@@ -9,6 +9,7 @@ import sullog.backend.common.entity.BaseEntity;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -93,6 +94,14 @@ public class Member extends BaseEntity implements UserDetails {
                 .memberId((int)attributes.get("memberId"))
                 .email((String)attributes.get("email"))
                 .nickName((String)attributes.get("name"))
+                .build();
+    }
+
+    public static Member ofRegisterMember(String email, String nickName) {
+        return Member.builder()
+                .email(email)
+                .nickName(nickName)
+                .searchWordList(Collections.EMPTY_LIST)
                 .build();
     }
 }


### PR DESCRIPTION
## 개요
- #66 이슈에서 협의한 대로 수정

## 작업사항
- 회원가입 시 써드파티 인증서버에서 가져온 데이터로 술로그 member객체 만들 때, 최근검색어 필드가 기본값(`[]`)으로 채워지도록 수정

## 변경로직
member 클래스의 최근검색어 기본값
- as-is: null
- to-be: []
