### PR TITLE
최근검색어 조회 시 사용자id를 알아낼 때 jwt토큰을 이용하도록 수정, api path 수정

### DIFF
--- a/backend/src/main/java/sullog/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/MemberController.java
@@ -20,10 +20,9 @@ public class MemberController {
     }
 
 
-    @GetMapping("/{memberId}/recent-search-history")
-    public ResponseEntity<RecentSearchHistoryDto> getRecentSearchHistory(
-            @PathVariable int memberId) {
-
+    @GetMapping("/me/recent-search-history")
+    public ResponseEntity<RecentSearchHistoryDto> getRecentSearchHistory(@RequestHeader String authorization) {
+        int memberId = tokenService.getMemberId(authorization);
         return new ResponseEntity<>(memberService.getRecentSearchHistory(memberId), HttpStatus.OK);
     }
 


### PR DESCRIPTION
## 개요
- https://github.com/sullog-official/sullog-server/issues/55 에 해당하는 api였는데, 이슈작성당시 작업 대상에서 누락되었습니다 

## 작업사항
- 최근검색어 조회 api 에서 특정 사용자를 나타내기 위해 path로 처리하던 부분을 jwt token기반으로 처리되도록 수정하고, api path수정

## 변경로직
- as-is: {memberId}
- to-be: me, jwt토큰에서 memberId 가져오기
