### PR TITLE
[docs] v4 배포에 따른 API 문서 수정 및 테스트 코드 변경

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -19,6 +19,12 @@
 | 2023-04-02
 | v2
 | https://www.notion.so/shinwonse/2-050b8e1d0ba74847b1466e08cc65eb46
+| 2023-04-06
+| v3
+| https://www.notion.so/shinwonse/3-56c5133bfb47453eb6ce3ddcee4e6f76
+| 2023-04-13
+| v4
+| https://www.notion.so/shinwonse/4-35923a3dbf4f424fb9e3036174190d24
 
 |===
 
@@ -58,7 +64,7 @@ include::{snippets}/token-refresh/response-headers.adoc[]
 === 최근 검색어 조회
 ==== Request
 include::{snippets}/member-get-recent-search/http-request.adoc[]
-include::{snippets}/member-get-recent-search/path-parameters.adoc[]
+include::{snippets}/member-get-recent-search/request-headers.adoc[]
 
 ==== Response
 include::{snippets}/member-get-recent-search/http-response.adoc[]

--- a/backend/src/main/resources/static/docs/api-doc.html
+++ b/backend/src/main/resources/static/docs/api-doc.html
@@ -521,6 +521,16 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <td class="tableblock halign-left valign-top"><p class="tableblock">v2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.notion.so/shinwonse/2-050b8e1d0ba74847b1466e08cc65eb46" class="bare">https://www.notion.so/shinwonse/2-050b8e1d0ba74847b1466e08cc65eb46</a></p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-04-06</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">v3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.notion.so/shinwonse/3-56c5133bfb47453eb6ce3ddcee4e6f76" class="bare">https://www.notion.so/shinwonse/3-56c5133bfb47453eb6ce3ddcee4e6f76</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-04-13</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">v4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.notion.so/shinwonse/4-35923a3dbf4f424fb9e3036174190d24" class="bare">https://www.notion.so/shinwonse/4-35923a3dbf4f424fb9e3036174190d24</a></p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -670,27 +680,27 @@ Refresh: sample_refresh_token</code></pre>
 <h4 id="_request_3">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/1/recent-search-history HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/me/recent-search-history HTTP/1.1
 Content-Type: application/json
+Authorization: sample_token
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /members/{memberId}/recent-search-history</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">멤버 아이디</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자의 access token</p></td>
 </tr>
 </tbody>
 </table>
@@ -900,7 +910,7 @@ test2
 Content-Disposition: form-data; name=recordInfo
 Content-Type: application/json
 
-{"alcoholId":1,"title":"Test record","alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"scentScore":3,"tasteScore":4,"textureScore":5,"description":"This is a test record.","experienceDate":"2023-04-03"}
+{"alcoholId":1,"title":"Test record","alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"scentScore":3,"tasteScore":4,"textureScore":5,"description":"This is a test record.","experienceDate":"2023-04-13"}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -1109,7 +1119,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 2. /records/{recordId}</caption>
+<caption class="title">Table 1. /records/{recordId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -1851,7 +1861,7 @@ Content-Length: 686
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-03 00:12:30 +0900
+Last updated 2023-04-13 22:58:20 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
@@ -85,7 +85,15 @@ class MemberControllerTest {
 
     @Test
     public void 최근_검색어_조회() throws Exception {
+        // given
+        String accessToken = "sample_token";
+        int memberId = 0;
 
+        // when
+        doReturn(memberId).when(tokenService).getMemberId(accessToken);
+        doNothing().when(memberService).deleteMember(memberId);
+
+        // then
         RecentSearchHistoryDto recentSearchHistoryDto = RecentSearchHistoryDto.builder()
                 .recentSearchWordList(List.of("abc", "가나다"))
                 .build();
@@ -93,16 +101,17 @@ class MemberControllerTest {
         when(memberService.getRecentSearchHistory(anyInt())).thenReturn(recentSearchHistoryDto);
 
         mockMvc.perform(
-                        get("/members/{memberId}/recent-search-history", 1)
+                        get("/members/me/recent-search-history")
                                 .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, accessToken)
                 )
                 .andExpect(status().isOk())
                 .andDo( // rest docs 문서 작성 시작
                         document("member-get-recent-search",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                pathParameters(
-                                        parameterWithName("memberId").description("멤버 아이디")
+                                requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("사용자의 access token")
                                 ),
                                 responseFields( // response 필드 정보 입력
                                         fieldWithPath("recentSearchWordList").type(JsonFieldType.ARRAY).description("최근 검색어 리스트")


### PR DESCRIPTION
## 개요
- v4 배포에 따른 API 문서 수정 및 테스트 코드 변경

## 작업사항
- 이전 MemberController의 #73 수정에 따른 테스트코드 수정
- API 문서 버전 정보 추가

## 변경로직
- Test코드에서 Path variable로 memberId받던 부분 /me로 수정 후 헤더에 Authorization 담도록 수정
