### PR TITLE
서버 로그파일 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 	// Query logging
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
 
+	// logging
+	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml' // log4j2의 설정파일을 yml로 작성하기 위해서
+
 	//spring rest docs
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'

--- a/backend/src/main/java/sullog/backend/common/error/CommonControllerAdvice.java
+++ b/backend/src/main/java/sullog/backend/common/error/CommonControllerAdvice.java
@@ -1,5 +1,6 @@
 package sullog.backend.common.error;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,22 +10,19 @@ import sullog.backend.common.error.exception.CommonException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+@Slf4j
 @RestControllerAdvice
 public class CommonControllerAdvice {
 
     @ExceptionHandler(Exception.class)
     ResponseEntity<String> exceptionHandler(Exception e) {
-
-        e.printStackTrace();
-
+        log.error("예외 발생", e);
         return new ResponseEntity<>(getSystemErrorMessage(e), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(CommonException.class)
     ResponseEntity<String> commonExceptionHandler(CommonException e) {
-
-        e.printStackTrace();
-
+        log.error("예외 발생", e);
         return new ResponseEntity<>(e.getErrorCode().toString(), HttpStatus.BAD_REQUEST);
     }
 

--- a/backend/src/main/java/sullog/backend/member/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/sullog/backend/member/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package sullog.backend.member.config.jwt;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -8,6 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 

--- a/backend/src/main/java/sullog/backend/record/mapper/typehandler/FlavorTagListTypeHandler.java
+++ b/backend/src/main/java/sullog/backend/record/mapper/typehandler/FlavorTagListTypeHandler.java
@@ -3,6 +3,7 @@ package sullog.backend.record.mapper.typehandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 import sullog.backend.record.entity.FlavorDetail;
@@ -13,6 +14,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
+@Slf4j
 public class FlavorTagListTypeHandler extends BaseTypeHandler<List<FlavorDetail>> {
 
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -43,11 +45,11 @@ public class FlavorTagListTypeHandler extends BaseTypeHandler<List<FlavorDetail>
 
     private List<FlavorDetail> jsonToFlavorTagMap(String jsonString) {
         try {
-            System.out.println("flavorTag = " + jsonString);
+            log.debug("jsonString={}", jsonString);
             return objectMapper.readValue(jsonString, new TypeReference<>() {
             });
         } catch (JsonProcessingException e) {
-            System.out.println("flavorTag = " + jsonString);
+            log.error("FlavorTagList 변환 시 에러 발생", e);
             throw new RuntimeException(e);
         }
     }

--- a/backend/src/main/resources/application-alpha.yml
+++ b/backend/src/main/resources/application-alpha.yml
@@ -22,3 +22,4 @@ logging:
       audit: off
       resultset: off
       connection: off
+  config: classpath:log4j2-alpha.yml

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -23,3 +23,5 @@ logging:
       audit: off
       resultset: off
       connection: off
+  config: classpath:log4j2-local.yml
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,7 +9,6 @@ spring:
       max-request-size: 50MB
   profiles:
     include:
-      - oauth-alpha
       - jwt
       - aws
       - mybatis

--- a/backend/src/main/resources/log4j2-alpha.yml
+++ b/backend/src/main/resources/log4j2-alpha.yml
@@ -8,13 +8,6 @@ Configuration:
       value: "logs"
 
   Appenders:
-    Console:
-      name: Console_Appender
-      target: SYSTEM_OUT
-      PatternLayout:
-        pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
-            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
-
     RollingFile:
       - name: RollingFile_Appender
         fileName: ${log-path}/catalina.out
@@ -28,25 +21,23 @@ Configuration:
             modulate: true
           SizeBasedTriggeringPolicy:
             size: "10 MB"
-        DefaultRollOverStrategy:
-          max: 10
+        DefaultRollOverStrategy:    # 로그 파일 롤오버(최대 파일 크기, 파일 개수 등)를 처리하는 전략 (롤오버: 로그 파일이 특정 조건을 충족할 때 새로운 로그 파일로 교체되는 기능)
+          max: 10                   # 롤오버되는 파일의 최대 개수
           Delete:
             basePath: "${log-path}"
             maxDepth: "1"
             IfLastModified:
-              age: "P14D"
+              age: "P30D"           # 파일이 최종 수정된 후 얼마나 오래 지나야 삭제할 것인지(30일)
             IfAccumulatedFileCount:
-              exceeds: 140
+              exceeds: 140          # 롤오버된 파일들의 누적 개수가 몇 개를 초과할 때 삭제할 것인지
   Loggers:
     Root:
       level: info
       AppenderRef:
         - ref: RollingFile_Appender
-        - ref: Console_Appender
     Logger:
       - name: com.sullog.backend
         additivity: false
         level: info
         AppenderRef:
           - ref: RollingFile_Appender
-          - ref: Console_Appender

--- a/backend/src/main/resources/log4j2-alpha.yml
+++ b/backend/src/main/resources/log4j2-alpha.yml
@@ -1,0 +1,52 @@
+Configuration:
+  name: Default
+  status: info
+
+  Properties:
+    Property:
+      name: log-path
+      value: "logs"
+
+  Appenders:
+    Console:
+      name: Console_Appender
+      target: SYSTEM_OUT
+      PatternLayout:
+        pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
+            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
+
+    RollingFile:
+      - name: RollingFile_Appender
+        fileName: ${log-path}/catalina.out
+        filePattern: "${log-path}/catalina.out.%d{yyyy-MM-dd}.gz"
+        PatternLayout:
+          pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
+            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
+        Policies:
+          TimeBasedTriggeringPolicy:
+            Interval: 1
+            modulate: true
+          SizeBasedTriggeringPolicy:
+            size: "10 MB"
+        DefaultRollOverStrategy:
+          max: 10
+          Delete:
+            basePath: "${log-path}"
+            maxDepth: "1"
+            IfLastModified:
+              age: "P14D"
+            IfAccumulatedFileCount:
+              exceeds: 140
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        - ref: RollingFile_Appender
+        - ref: Console_Appender
+    Logger:
+      - name: com.sullog.backend
+        additivity: false
+        level: info
+        AppenderRef:
+          - ref: RollingFile_Appender
+          - ref: Console_Appender

--- a/backend/src/main/resources/log4j2-live.yml
+++ b/backend/src/main/resources/log4j2-live.yml
@@ -1,0 +1,43 @@
+Configuration:
+  name: Default
+  status: info
+
+  Properties:
+    Property:
+      name: log-path
+      value: "logs"
+
+  Appenders:
+    RollingFile:
+      - name: RollingFile_Appender
+        fileName: ${log-path}/catalina.out
+        filePattern: "${log-path}/catalina.out.%d{yyyy-MM-dd}.gz"
+        PatternLayout:
+          pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
+            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
+        Policies:
+          TimeBasedTriggeringPolicy:
+            Interval: 1
+            modulate: true
+          SizeBasedTriggeringPolicy:
+            size: "10 MB"
+        DefaultRollOverStrategy:
+          max: 10
+          Delete:
+            basePath: "${log-path}"
+            maxDepth: "1"
+            IfLastModified:
+              age: "P14D"
+            IfAccumulatedFileCount:
+              exceeds: 140
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        - ref: RollingFile_Appender
+    Logger:
+      - name: com.sullog.backend
+        additivity: false
+        level: info
+        AppenderRef:
+          - ref: RollingFile_Appender

--- a/backend/src/main/resources/log4j2-live.yml
+++ b/backend/src/main/resources/log4j2-live.yml
@@ -27,7 +27,7 @@ Configuration:
             basePath: "${log-path}"
             maxDepth: "1"
             IfLastModified:
-              age: "P14D"
+              age: "P30D"
             IfAccumulatedFileCount:
               exceeds: 140
   Loggers:

--- a/backend/src/main/resources/log4j2-local.yml
+++ b/backend/src/main/resources/log4j2-local.yml
@@ -1,0 +1,28 @@
+Configuration:
+  name: Default
+  status: info
+
+  Properties:
+    Property:
+      name: log-path
+      value: "logs"
+
+  Appenders:
+    Console:
+      name: Console_Appender
+      target: SYSTEM_OUT
+      PatternLayout:
+        pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
+            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        - ref: Console_Appender
+    Logger:
+      - name: com.sullog.backend
+        additivity: false
+        level: debug
+        AppenderRef:
+          - ref: Console_Appender


### PR DESCRIPTION
## 개요
- 알파, 리얼 환경의 원활한 운영을 위해 로그 관련 작업 진행(#24)

## 작업사항
- log4j2 라이브러리를 이용해 로그파일 설정 및 기록성 코드 수정

## 변경로직
- log4j2 관련 설정파일 추가
  - local: console 로그만 남김
  - alpha, live: log 폴더 하위에 catalina.out 이름으로 로그 기록을 파일로 저장 
- system.out.println, printStackTrace() 같은 코드는 log.xxx로 수정

## 참고 
- 라이브러리 선정 배경(#78)
- 로그 남길 때 사용방법: 클래스 상단에 @Sl4j2 어노테이션 추가, log.xxx 로 작성
