### PR TITLE
fix: 경험(Record) 도메인에 별점 필드 추가, 제목 필드 삭제

### DIFF
--- a/backend/src/main/java/sullog/backend/record/dto/RecordSaveRequestDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/RecordSaveRequestDto.java
@@ -12,13 +12,13 @@ import java.util.List;
 public class RecordSaveRequestDto {
     private Integer alcoholId; // 술 id
 
-    private String title; // 제목
-
     private AlcoholPercentFeeling alcoholPercentFeeling; // 도수 느낌
 
     private List<FlavorDetail> flavorTagList; // 상세 플레이버 태그
 
-    private Integer scentScore; //향점수(1~5)
+    private Integer starScore; // 별점(1~5)
+
+    private Integer scentScore; // 향점수(1~5)
 
     private Integer tasteScore; // 맛점수 (1~5)
 
@@ -33,18 +33,18 @@ public class RecordSaveRequestDto {
 
     public RecordSaveRequestDto(
             Integer alcoholId,
-            String title,
             AlcoholPercentFeeling alcoholPercentFeeling,
             List<FlavorDetail> flavorTagList,
+            Integer starScore,
             Integer scentScore,
             Integer tasteScore,
             Integer textureScore,
             String description,
             LocalDate experienceDate) {
         this.alcoholId = alcoholId;
-        this.title = title;
         this.alcoholPercentFeeling = alcoholPercentFeeling;
         this.flavorTagList = flavorTagList;
+        this.starScore = starScore;
         this.scentScore = scentScore;
         this.tasteScore = tasteScore;
         this.textureScore = textureScore;
@@ -56,16 +56,16 @@ public class RecordSaveRequestDto {
         return alcoholId;
     }
 
-    public String getTitle() {
-        return title;
-    }
-
     public AlcoholPercentFeeling getAlcoholPercentFeeling() {
         return alcoholPercentFeeling;
     }
 
     public List<FlavorDetail> getFlavorTagList() {
         return flavorTagList;
+    }
+
+    public Integer getStarScore() {
+        return starScore;
     }
 
     public Integer getScentScore() {
@@ -88,14 +88,15 @@ public class RecordSaveRequestDto {
         return experienceDate;
     }
 
-    public Record toEntity(int memberId, List<String> photoPathList) {
+    public Record toEntity(int memberId,
+                           List<String> photoPathList) {
         return Record.builder()
                 .memberId(memberId)
                 .alcoholId(alcoholId)
-                .title(title)
                 .photoPathList(photoPathList)
                 .alcoholPercentFeeling(alcoholPercentFeeling)
                 .flavorTagList(flavorTagList)
+                .starScore(starScore)
                 .scentScore(scentScore)
                 .tasteScore(tasteScore)
                 .textureScore(textureScore)

--- a/backend/src/main/java/sullog/backend/record/entity/Record.java
+++ b/backend/src/main/java/sullog/backend/record/entity/Record.java
@@ -12,17 +12,18 @@ import java.util.List;
 public class Record extends BaseEntity {
 
     private int memberId;
+
     private int alcoholId;
 
     private int recordId; //auto increment
-
-    private String title; // 제목
 
     private List<String> photoPathList; // 사진 경로(3장까지)
 
     private AlcoholPercentFeeling alcoholPercentFeeling; // 도수 느낌
 
     private List<FlavorDetail> flavorTagList; // 상세 플레이버 태그
+
+    private int starScore; // 별점(1~5)
 
     private int scentScore; // 향 점수(1~5)
 
@@ -46,10 +47,10 @@ public class Record extends BaseEntity {
             int memberId,
             int alcoholId,
             int recordId,
-            String title,
             List<String> photoPathList,
             AlcoholPercentFeeling alcoholPercentFeeling,
             List<FlavorDetail> flavorTagList,
+            int starScore,
             int scentScore,
             int tasteScore,
             int textureScore,
@@ -59,10 +60,10 @@ public class Record extends BaseEntity {
         this.memberId = memberId;
         this.alcoholId = alcoholId;
         this.recordId = recordId;
-        this.title = title;
         this.photoPathList = photoPathList;
         this.alcoholPercentFeeling = alcoholPercentFeeling;
         this.flavorTagList = flavorTagList;
+        this.starScore = starScore;
         this.scentScore = scentScore;
         this.tasteScore = tasteScore;
         this.textureScore = textureScore;
@@ -82,8 +83,8 @@ public class Record extends BaseEntity {
         return recordId;
     }
 
-    public String getTitle() {
-        return title;
+    public int getStarScore() {
+        return starScore;
     }
 
     public List<String> getPhotoPathList() {

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -9,10 +9,10 @@
         (
             member_id,
             alcohol_id,
-            title,
             photo_path,
             alcohol_percent_feeling,
             flavor_tag_list,
+            star_score,
             scent_score,
             taste_score,
             texture_score,
@@ -22,10 +22,10 @@
         VALUES (
                    #{memberId},
                    #{alcoholId},
-                   #{title},
                    #{photoPathList, typeHandler=sullog.backend.common.mapper.typehandler.StringListTypeHandler},
                    #{alcoholPercentFeeling, typeHandler=sullog.backend.record.mapper.typehandler.AlcoholPercentFeelingTypeHandler},
                    #{flavorTagList, typeHandler=sullog.backend.record.mapper.typehandler.FlavorTagListTypeHandler},
+                   #{starScore},
                    #{scentScore},
                    #{tasteScore},
                    #{textureScore},
@@ -77,10 +77,10 @@
         <result property="recordId" column="record_id"/>
         <result property="memberId" column="member_id"/>
         <result property="alcoholId" column="alcohol_id"/>
-        <result property="title" column="title"/>
         <result property="photoPathList" column="photo_path" typeHandler="sullog.backend.common.mapper.typehandler.StringListTypeHandler"/>
         <result property="alcoholPercentFeeling" column="alcohol_percent_feeling" typeHandler="sullog.backend.record.mapper.typehandler.AlcoholPercentFeelingTypeHandler"/>
         <result property="flavorTagList" column="flavor_tag_list" typeHandler="sullog.backend.record.mapper.typehandler.FlavorTagListTypeHandler"/>
+        <result property="starScore" column="star_score"/>
         <result property="tasteScore" column="taste_score"/>
         <result property="scentScore" column="scent_score"/>
         <result property="textureScore" column="texture_score"/>
@@ -92,10 +92,10 @@
         SELECT record_id,
                member_id,
                alcohol_id,
-               title,
                photo_path,
                alcohol_percent_feeling,
                flavor_tag_list,
+               star_score,
                taste_score,
                scent_score,
                texture_score,

--- a/backend/src/main/resources/static/docs/api-doc.html
+++ b/backend/src/main/resources/static/docs/api-doc.html
@@ -915,7 +915,7 @@ test2
 Content-Disposition: form-data; name=recordInfo
 Content-Type: application/json
 
-{"alcoholId":1,"title":"Test record","alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"scentScore":3,"tasteScore":4,"textureScore":5,"description":"This is a test record.","experienceDate":"2023-04-16"}
+{"alcoholId":1,"alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"starScore":5,"scentScore":3,"tasteScore":4,"textureScore":5,"description":"This is a test record.","experienceDate":"2023-04-23"}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -961,11 +961,6 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock">술 id</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>alcoholPercentFeeling</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">도수 느낌. 값은 별첨 참고)</p></td>
@@ -984,6 +979,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>flavorTagList[0].detailTag</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">2분류</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>starScore</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">별점 (1~5)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>scentScore</code></p></td>
@@ -1149,9 +1149,9 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 601
+Content-Length: 592
 
-{"record":{"memberId":1,"alcoholId":1,"recordId":0,"title":"Dummy Data 1","photoPathList":["path1","path2"],"alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"scentScore":4,"tasteScore":3,"textureScore":2,"description":"This is a dummy data 1","experienceDate":"2022-03-04"},"alcoholInfo":{"alcoholName":"전통주 샘플","brandName":"진로","alcoholPercent":10.0,"productionLocation":"서울시 광진구","productionLatitude":127.077794504202,"productionLongitude":37.54373496690244,"alcoholTag":"SOJU"}}</code></pre>
+{"record":{"memberId":1,"alcoholId":1,"recordId":0,"photoPathList":["path1","path2"],"alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"starScore":5,"scentScore":4,"tasteScore":3,"textureScore":2,"description":"This is a dummy data 1","experienceDate":"2022-03-04"},"alcoholInfo":{"alcoholName":"전통주 샘플","brandName":"진로","alcoholPercent":10.0,"productionLocation":"서울시 광진구","productionLatitude":127.077794504202,"productionLongitude":37.54373496690244,"alcoholTag":"SOJU"}}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1189,11 +1189,6 @@ Content-Length: 601
 <td class="tableblock halign-left valign-top"><p class="tableblock">전통주 id</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>record.title</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">제목</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>record.photoPathList</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">사진 경로(3장까지)</p></td>
@@ -1217,6 +1212,11 @@ Content-Length: 601
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>record.flavorTagList[].detailTag</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">상세 플레이버 태그 - 2분류(optional)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>record.starScore</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">별점(1~5)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>record.scentScore</code></p></td>
@@ -1866,7 +1866,7 @@ Content-Length: 686
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-16 22:32:00 +0900
+Last updated 2023-04-16 23:11:55 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -93,9 +93,9 @@ class RecordControllerTest {
         List<FlavorDetail> flavorDetailList = Arrays.asList(FlavorDetail.of("FLOWER", "CHRYSANTHEMUM"), FlavorDetail.of("DAIRY", "BUTTER"));
         RecordSaveRequestDto requestDto = RecordSaveRequestDto.builder()
                 .alcoholId(1)
-                .title("Test record")
                 .alcoholPercentFeeling(AlcoholPercentFeeling.STRONG)
                 .flavorTagList(flavorDetailList)
+                .starScore(5)
                 .scentScore(3)
                 .tasteScore(4)
                 .textureScore(5)
@@ -130,11 +130,11 @@ class RecordControllerTest {
                         )),
                         requestPartFields("recordInfo", List.of(
                                 fieldWithPath("alcoholId").type(JsonFieldType.NUMBER).description("술 id"),
-                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
                                 fieldWithPath("alcoholPercentFeeling").type(JsonFieldType.STRING).description("도수 느낌. 값은 별첨 참고)"),
                                 fieldWithPath("flavorTagList").type(JsonFieldType.ARRAY).description("상세 플레이버 태그(optional). 값은 별첨 참고").optional(),
                                 fieldWithPath("flavorTagList[0].majorTag").type(JsonFieldType.STRING).description("1분류").optional(),
                                 fieldWithPath("flavorTagList[0].detailTag").type(JsonFieldType.STRING).description("2분류").optional(),
+                                fieldWithPath("starScore").type(JsonFieldType.NUMBER).description("별점 (1~5)"),
                                 fieldWithPath("scentScore").type(JsonFieldType.NUMBER).description("향점수 (1~5)"),
                                 fieldWithPath("tasteScore").type(JsonFieldType.NUMBER).description("맛점수 (1~5)"),
                                 fieldWithPath("textureScore").type(JsonFieldType.NUMBER).description("감촉점수 (1~5)"),
@@ -257,12 +257,12 @@ class RecordControllerTest {
                                 fieldWithPath("record.recordId").type(JsonFieldType.NUMBER).description("기록 id"),
                                 fieldWithPath("record.memberId").type(JsonFieldType.NUMBER).description("작성자 id"),
                                 fieldWithPath("record.alcoholId").type(JsonFieldType.NUMBER).description("전통주 id"),
-                                fieldWithPath("record.title").type(JsonFieldType.STRING).description("제목"),
                                 fieldWithPath("record.photoPathList").type(JsonFieldType.ARRAY).description("사진 경로(3장까지)").optional(),
                                 fieldWithPath("record.alcoholPercentFeeling").type(JsonFieldType.STRING).description("도수 느낌. 값은 별첨 참고"),
                                 fieldWithPath("record.flavorTagList").type(JsonFieldType.ARRAY).description("상세 플레이버 태그(optional). 값은 별첨 참고").optional(),
                                 fieldWithPath("record.flavorTagList[].majorTag").type(JsonFieldType.STRING).description("상세 플레이버 태그 - 1분류(optional)").optional(),
                                 fieldWithPath("record.flavorTagList[].detailTag").type(JsonFieldType.STRING).description("상세 플레이버 태그 - 2분류(optional)").optional(),
+                                fieldWithPath("record.starScore").type(JsonFieldType.NUMBER).description("별점(1~5)"),
                                 fieldWithPath("record.scentScore").type(JsonFieldType.NUMBER).description("향 점수(1~5)"),
                                 fieldWithPath("record.tasteScore").type(JsonFieldType.NUMBER).description("맛점수 (1~5)"),
                                 fieldWithPath("record.textureScore").type(JsonFieldType.NUMBER).description("감촉점수 (1~5)"),
@@ -286,10 +286,10 @@ class RecordControllerTest {
         return Record.builder()
                 .memberId(1)
                 .alcoholId(1)
-                .title("Dummy Data 1")
                 .photoPathList(Arrays.asList("path1", "path2"))
                 .alcoholPercentFeeling(AlcoholPercentFeeling.STRONG)
                 .flavorTagList(Arrays.asList(FlavorDetail.of("FLOWER", "CHRYSANTHEMUM"), FlavorDetail.of("DAIRY", "BUTTER")))
+                .starScore(5)
                 .scentScore(4)
                 .tasteScore(3)
                 .textureScore(2)


### PR DESCRIPTION
## 개요
- 경험(Record) 도메인에 별점 필드 추가, 제목 필드 삭제

## 작업사항
- 경험파트에서 별점 필드 누락 이슈에 따른 별점 필드 추가 및 테스트 수정(#82)
- 경험파트에서 제목 컬럼이 불필요하다는 이슈에 따른 제목 필드 삭제 및 테스트 수점(#87)
- DB 컬럼 수정 및 ERD 수정