### PR TITLE
최근 검색어 중 특정 키워드 제거, 최근 검색어 목록 초기화 api

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.0'
 
+    // json 처리
+    implementation 'com.google.code.gson:gson:2.8.9'
+
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -72,6 +72,23 @@ include::{snippets}/member-get-recent-search/request-headers.adoc[]
 ==== Response
 include::{snippets}/member-get-recent-search/http-response.adoc[]
 
+=== 최근 검색어 중 특정 검색어 제거
+==== Request
+include::{snippets}/member/delete-specific-keyword/http-request.adoc[]
+include::{snippets}/member/delete-specific-keyword/request-headers.adoc[]
+include::{snippets}/member/delete-specific-keyword/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/member/delete-specific-keyword/http-response.adoc[]
+
+=== 최근 검색어 목록 초기화
+==== Request
+include::{snippets}/member/clear-specific-keywords/http-request.adoc[]
+include::{snippets}/member/clear-specific-keywords/request-headers.adoc[]
+
+==== Response
+include::{snippets}/member/clear-specific-keywords/http-response.adoc[]
+
 === 회원 탈퇴
 ==== Request
 include::{snippets}/member/delete-member/http-request.adoc[]

--- a/backend/src/main/java/sullog/backend/common/mapper/typehandler/StringListTypeHandler.java
+++ b/backend/src/main/java/sullog/backend/common/mapper/typehandler/StringListTypeHandler.java
@@ -1,8 +1,7 @@
 package sullog.backend.common.mapper.typehandler;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 
@@ -14,15 +13,11 @@ import java.util.List;
 
 public class StringListTypeHandler extends BaseTypeHandler<List<String>> {
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private Gson gson = new Gson();
 
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, List<String> parameter, JdbcType jdbcType) throws SQLException {
-        try {
-            ps.setString(i, objectMapper.writeValueAsString(parameter));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        ps.setString(i, gson.toJson(parameter));
     }
 
     @Override
@@ -41,11 +36,6 @@ public class StringListTypeHandler extends BaseTypeHandler<List<String>> {
     }
 
     private List<String> jsonToStringList(String rs) {
-        try {
-            return objectMapper.readValue(rs, new TypeReference<>() {});
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+        return gson.fromJson(rs, new TypeToken<List<String>>() {}.getType());
     }
 }

--- a/backend/src/main/java/sullog/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/MemberController.java
@@ -19,11 +19,27 @@ public class MemberController {
         this.tokenService = tokenService;
     }
 
-
     @GetMapping("/me/recent-search-history")
     public ResponseEntity<RecentSearchHistoryDto> getRecentSearchHistory(@RequestHeader String authorization) {
         int memberId = tokenService.getMemberId(authorization);
         return new ResponseEntity<>(memberService.getRecentSearchHistory(memberId), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/me/recent-search-history/{keyword}")
+    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestHeader String authorization,
+                                                            @PathVariable String keyword) {
+        int memberId = tokenService.getMemberId(authorization);
+        memberService.removeSearchKeyword(memberId, keyword);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/me/recent-search-history")
+    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestHeader String authorization) {
+        int memberId = tokenService.getMemberId(authorization);
+        memberService.clearRecentSearchKeyword(memberId);
+
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/me")

--- a/backend/src/main/java/sullog/backend/member/entity/Member.java
+++ b/backend/src/main/java/sullog/backend/member/entity/Member.java
@@ -9,7 +9,6 @@ import sullog.backend.common.entity.BaseEntity;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -101,7 +100,7 @@ public class Member extends BaseEntity implements UserDetails {
         return Member.builder()
                 .email(email)
                 .nickName(nickName)
-                .searchWordList(Collections.EMPTY_LIST)
+                .searchWordList(List.of())
                 .build();
     }
 }

--- a/backend/src/main/java/sullog/backend/member/service/MemberService.java
+++ b/backend/src/main/java/sullog/backend/member/service/MemberService.java
@@ -17,10 +17,20 @@ public class MemberService {
     }
 
     public RecentSearchHistoryDto getRecentSearchHistory(int memberId) {
-        List<String> recentSearchList = memberMapper.selectRecentSearchHistory(memberId);
+        List<String> recentSearchList = findMemberById(memberId).getSearchWordList();
         return RecentSearchHistoryDto.builder()
                 .recentSearchWordList(recentSearchList)
                 .build();
+    }
+
+    public void removeSearchKeyword(int memberId, String keyword) {
+        List<String> recentSearchList = findMemberById(memberId).getSearchWordList();
+        recentSearchList.remove(keyword);
+        memberMapper.updateSearchWordList(memberId, recentSearchList);
+    }
+
+    public void clearRecentSearchKeyword(int memberId) {
+        memberMapper.updateSearchWordList(memberId, List.of());
     }
 
     public void registerMember(Member member) {

--- a/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/sullog/backend/member/controller/MemberControllerTest.java
@@ -120,4 +120,61 @@ class MemberControllerTest {
                 )
         ;
     }
+
+    @Test
+    void 최근검색어리스트에서_특정검색어를_제거한다() throws Exception {
+        // given
+        String accessToken = "sample_token";
+        int memberId = 0;
+        String keyword = "abc";
+
+        // when
+        doReturn(memberId).when(tokenService).getMemberId(accessToken);
+        doNothing().when(memberService).removeSearchKeyword(memberId, keyword);
+
+        // then
+        mockMvc.perform(
+                        delete("/members/me/recent-search-history/{keyword}", keyword)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                )
+                .andExpect(status().isOk())
+                .andDo( // rest docs 문서 작성 시작
+                        document("member/delete-specific-keyword",
+                                pathParameters(parameterWithName("keyword").description("삭제할 키워드")),
+                                requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("사용자의 access token")
+                                )
+                        )
+                )
+        ;
+    }
+
+    @Test
+    void 최근검색어를_전부_초기화한다() throws Exception {
+        // given
+        String accessToken = "sample_token";
+        int memberId = 0;
+        String keyword = "abc";
+
+        // when
+        doReturn(memberId).when(tokenService).getMemberId(accessToken);
+        doNothing().when(memberService).clearRecentSearchKeyword(memberId);
+
+        // then
+        mockMvc.perform(
+                        delete("/members/me/recent-search-history")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                )
+                .andExpect(status().isOk())
+                .andDo( // rest docs 문서 작성 시작
+                        document("member/clear-specific-keywords",
+                                requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("사용자의 access token")
+                                )
+                        )
+                )
+        ;
+    }
 }


### PR DESCRIPTION
## 개요
아래 2가지 api 작업
- 최근 검색어 중 특정 키워드 제거
- 최근 검색어 목록 초기화

## 작업사항
- gson 의존성 추가 (json문자열 리스트를 List<String>으로 변환 시 이중으로 인코딩 되는 이슈가 있어서 jackson 라이브러리에서 변경)
- 타입핸들러 이슈가 있어서, 최근검색어리스트 조회 시 멤버 조회 후 최근검색어 리스트 참조하도록 수정
  - 이 부분은 깊은 트래킹이 필요해보임 ..  (#30 )

## 변경로직
- 상동
