### PR TITLE
JWT 토큰은 Bearer 타입만 허용하도록 수정

### DIFF
--- a/backend/src/main/java/sullog/backend/alcohol/controller/AlcoholController.java
+++ b/backend/src/main/java/sullog/backend/alcohol/controller/AlcoholController.java
@@ -1,19 +1,13 @@
 package sullog.backend.alcohol.controller;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sullog.backend.alcohol.dto.request.AlcoholSearchRequestDto;
 import sullog.backend.alcohol.dto.response.AlcoholInfoDto;
 import sullog.backend.alcohol.dto.response.AlcoholInfoWithPagingDto;
 import sullog.backend.alcohol.service.AlcoholService;
 import sullog.backend.auth.service.TokenService;
-
-import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/alcohols")
@@ -21,11 +15,8 @@ public class AlcoholController {
 
     private final AlcoholService alcoholService;
 
-    private final TokenService tokenService;
-
-    public AlcoholController(AlcoholService alcoholService, TokenService tokenService) {
+    public AlcoholController(AlcoholService alcoholService) {
         this.alcoholService = alcoholService;
-        this.tokenService = tokenService;
     }
 
     @GetMapping
@@ -35,12 +26,8 @@ public class AlcoholController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<AlcoholInfoWithPagingDto> getAlcoholIdListWithKeywordAndCursor(
-            HttpServletRequest request,
-            AlcoholSearchRequestDto alcoholSearchRequestDto) {
-        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        int memberId = tokenService.getMemberId(token);
-
+    public ResponseEntity<AlcoholInfoWithPagingDto> getAlcoholIdListWithKeywordAndCursor(@RequestAttribute Integer memberId,
+                                                                                         AlcoholSearchRequestDto alcoholSearchRequestDto) {
         return new ResponseEntity<>(alcoholService.getAlcoholInfo(memberId, alcoholSearchRequestDto), HttpStatus.OK);
     }
 

--- a/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sullog.backend.auth.service.KakaoService;
@@ -11,9 +12,6 @@ import sullog.backend.member.entity.Member;
 import sullog.backend.member.entity.Token;
 import sullog.backend.auth.service.TokenService;
 import sullog.backend.member.service.MemberService;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 @RestController
 public class AuthController {
@@ -29,9 +27,7 @@ public class AuthController {
     }
 
     @GetMapping("/token/refresh")
-    public ResponseEntity<Void> refreshAuth(HttpServletRequest request) {
-        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        int memberId = tokenService.getMemberId(token);
+    public ResponseEntity<Void> refreshAuth(@RequestAttribute Integer memberId) {
         Token newToken = tokenService.generateToken(memberId, "USER");
 
         // response 생성

--- a/backend/src/main/java/sullog/backend/common/config/WebMvcConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package sullog.backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import sullog.backend.common.interceptor.MemberIdInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final MemberIdInterceptor memberIdInterceptor;
+
+    public WebMvcConfig(MemberIdInterceptor memberIdInterceptor) {
+        this.memberIdInterceptor = memberIdInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(memberIdInterceptor);
+    }
+}

--- a/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
+++ b/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
@@ -1,0 +1,27 @@
+package sullog.backend.common.interceptor;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import sullog.backend.auth.service.TokenService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class MemberIdInterceptor extends HandlerInterceptorAdapter {
+
+    private final TokenService tokenService;
+
+    public MemberIdInterceptor(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        Integer memberId = tokenService.getMemberId(token);
+        request.setAttribute("memberId", memberId);
+        return true;
+    }
+}

--- a/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
+++ b/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
@@ -2,14 +2,14 @@ package sullog.backend.common.interceptor;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 import sullog.backend.auth.service.TokenService;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
-public class MemberIdInterceptor extends HandlerInterceptorAdapter {
+public class MemberIdInterceptor implements HandlerInterceptor {
 
     private final TokenService tokenService;
 
@@ -18,7 +18,7 @@ public class MemberIdInterceptor extends HandlerInterceptorAdapter {
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
         Integer memberId = tokenService.getMemberId(token);
         request.setAttribute("memberId", memberId);

--- a/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
+++ b/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
@@ -20,6 +20,9 @@ public class MemberIdInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (null == token) { // permitAll로 처리되는 요청은 jwtToken값을 실어보내지 않으므로, 방어로직 추가
+            return true;
+        }
         Integer memberId = tokenService.getMemberId(token);
         request.setAttribute("memberId", memberId);
         return true;

--- a/backend/src/main/java/sullog/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/MemberController.java
@@ -12,39 +12,33 @@ import sullog.backend.member.dto.response.RecentSearchHistoryDto;
 public class MemberController {
 
     private final MemberService memberService;
-    private final TokenService tokenService;
 
-    public MemberController(MemberService memberService, TokenService tokenService) {
+    public MemberController(MemberService memberService) {
         this.memberService = memberService;
-        this.tokenService = tokenService;
     }
 
     @GetMapping("/me/recent-search-history")
-    public ResponseEntity<RecentSearchHistoryDto> getRecentSearchHistory(@RequestHeader String authorization) {
-        int memberId = tokenService.getMemberId(authorization);
+    public ResponseEntity<RecentSearchHistoryDto> getRecentSearchHistory(@RequestAttribute Integer memberId) {
         return new ResponseEntity<>(memberService.getRecentSearchHistory(memberId), HttpStatus.OK);
     }
 
     @DeleteMapping("/me/recent-search-history/{keyword}")
-    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestHeader String authorization,
+    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestAttribute Integer memberId,
                                                             @PathVariable String keyword) {
-        int memberId = tokenService.getMemberId(authorization);
         memberService.removeSearchKeyword(memberId, keyword);
 
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/me/recent-search-history")
-    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestHeader String authorization) {
-        int memberId = tokenService.getMemberId(authorization);
+    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestAttribute Integer memberId) {
         memberService.clearRecentSearchKeyword(memberId);
 
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMember(@RequestHeader String authorization) {
-        int memberId = tokenService.getMemberId(authorization);
+    public ResponseEntity<Void> deleteMember(@RequestAttribute Integer memberId) {
         memberService.deleteMember(memberId);
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -24,25 +24,20 @@ import java.util.stream.Collectors;
 @RequestMapping("/records")
 public class RecordController {
 
-    private final TokenService tokenService;
     private final RecordService recordService;
     private final ImageUploadService imageUploadService;
     private final AlcoholService alcoholService;
 
-    public RecordController(TokenService tokenService, RecordService recordService, ImageUploadService imageUploadService, AlcoholService alcoholService) {
-        this.tokenService = tokenService;
+    public RecordController(RecordService recordService, ImageUploadService imageUploadService, AlcoholService alcoholService) {
         this.recordService = recordService;
         this.imageUploadService = imageUploadService;
         this.alcoholService = alcoholService;
     }
 
     @PostMapping
-    public ResponseEntity<Void> saveRecord(@RequestHeader(name="Authorization") String accessToken,
+    public ResponseEntity<Void> saveRecord(@RequestAttribute Integer memberId,
                         @RequestPart(required = false) List<MultipartFile> photoList,
                         @RequestPart("recordInfo") RecordSaveRequestDto requestDto) {
-        // 작성자 조회
-        int memberId = tokenService.getMemberId(accessToken);
-
         // 이미지 저장
         List<String> photoPathList = imageUploadService.uploadImageList(photoList);
 
@@ -53,9 +48,7 @@ public class RecordController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<List<RecordMetaDto>> getRecords(@RequestHeader(name="Authorization") String accessToken) {
-        int memberId = tokenService.getMemberId(accessToken);
-
+    public ResponseEntity<List<RecordMetaDto>> getRecords(@RequestAttribute Integer memberId) {
         List<RecordMetaDto> recordMetaDtoList = recordService.getRecordMetasByMemberId(memberId).stream()
                 .map(RecordMetaWithAlcoholInfoDto::toResponseDto)
                 .collect(Collectors.toList());
@@ -80,11 +73,9 @@ public class RecordController {
     }
 
     @GetMapping("/me/search")
-    public ResponseEntity<RecordMetaListWithPagingDto> searchRecords(@RequestHeader(name="Authorization") String accessToken,
+    public ResponseEntity<RecordMetaListWithPagingDto> searchRecords(@RequestAttribute Integer memberId,
                                                                      RecordSearchParamDto recordSearchParamDto) {
-        int memberId = tokenService.getMemberId(accessToken);
-
-        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByCondition(memberId, recordSearchParamDto);
+       List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByCondition(memberId, recordSearchParamDto);
 
         RecordMetaListWithPagingDto recordMetaListWithPagingDto = RecordMetaListWithPagingDto.builder()
                 .recordMetaList(recordMetaWithAlcoholInfoList.stream()

--- a/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
+++ b/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
@@ -150,7 +150,7 @@ class AlcoholControllerTest {
                                 .queryParam("cursor", String.valueOf(alcoholSearchRequestDto.getCursor()))
                                 .queryParam("limit", String.valueOf(alcoholSearchRequestDto.getLimit()))
                                 .with(request -> {
-                                    request.addHeader("Authorization", "accessToken");
+                                    request.addHeader("Authorization", "Bearer accessToken");
                                     return request;
                                 })
                 )

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -116,7 +116,7 @@ class RecordControllerTest {
                         .file(mockMultipartFiles.get(1))
                         .file(new MockMultipartFile("recordInfo", "", "application/json", objectMapper.writeValueAsString(requestDto).getBytes(StandardCharsets.UTF_8)))
                         .with(request -> {
-                            request.addHeader("Authorization", "accessToken");
+                            request.addHeader("Authorization", "Bearer accessToken");
                             return request;
                         })
                 )
@@ -157,7 +157,7 @@ class RecordControllerTest {
         // when, then
         mockMvc.perform(get("/records/me")
                         .with(request -> {
-                            request.addHeader("Authorization", "accessToken");
+                            request.addHeader("Authorization", "Bearer accessToken");
                             return request;
                         }))
                 .andExpect(status().isOk())
@@ -335,7 +335,7 @@ class RecordControllerTest {
                         .param("keyword", recordSearchParamDto.getKeyword())
                         .param("limit", String.valueOf(recordSearchParamDto.getLimit()))
                         .with(request -> {
-                            request.addHeader("Authorization", "accessToken");
+                            request.addHeader("Authorization", "Bearer accessToken");
                             return request;
                         }))
                 .andExpect(status().isOk())
@@ -387,7 +387,7 @@ class RecordControllerTest {
                         .param("cursor", String.valueOf(recordSearchParamDto.getCursor()))
                         .param("limit", String.valueOf(recordSearchParamDto.getLimit()))
                         .with(request -> {
-                            request.addHeader("Authorization", "accessToken");
+                            request.addHeader("Authorization", "Bearer accessToken");
                             return request;
                         }))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 개요
- 기존엔 jwt token 처리 시 그저 jwt값만 이용했는데, 보안상 Bearer 타입만 허용하도록 수정
- [Bearer에 관한 설명 참고](https://velog.io/@cada/%ED%86%A0%EA%B7%BC-%EA%B8%B0%EB%B0%98-%EC%9D%B8%EC%A6%9D%EC%97%90%EC%84%9C-bearer%EB%8A%94-%EB%AC%B4%EC%97%87%EC%9D%BC%EA%B9%8C)

## 작업사항
- jwt token 관련 처리 시 Bearer 타입만 허용하도록 수정

## 변경로직
- 토큰 검증 로직: Bearer 프리픽스가 없으면 invalid한 토큰으로 처리
- 토큰 기반으로 memberId 추출하는 메서드: bearer 프리픽스 제외한 값을 이용하도록 수정

## 참고
배포 히스토리에 꼭 추가해야할 것) 클라이언트에서 보내는 jwt token은 이제 "bearer " prefix가 추가되어야 함
