### PR TITLE
jwtToken 기반 memberId 조회 로직을 인터셉터로 분리

### DIFF
--- a/backend/src/main/java/sullog/backend/alcohol/controller/AlcoholController.java
+++ b/backend/src/main/java/sullog/backend/alcohol/controller/AlcoholController.java
@@ -1,19 +1,13 @@
 package sullog.backend.alcohol.controller;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sullog.backend.alcohol.dto.request.AlcoholSearchRequestDto;
 import sullog.backend.alcohol.dto.response.AlcoholInfoDto;
 import sullog.backend.alcohol.dto.response.AlcoholInfoWithPagingDto;
 import sullog.backend.alcohol.service.AlcoholService;
 import sullog.backend.auth.service.TokenService;
-
-import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/alcohols")
@@ -21,11 +15,8 @@ public class AlcoholController {
 
     private final AlcoholService alcoholService;
 
-    private final TokenService tokenService;
-
-    public AlcoholController(AlcoholService alcoholService, TokenService tokenService) {
+    public AlcoholController(AlcoholService alcoholService) {
         this.alcoholService = alcoholService;
-        this.tokenService = tokenService;
     }
 
     @GetMapping
@@ -35,12 +26,8 @@ public class AlcoholController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<AlcoholInfoWithPagingDto> getAlcoholIdListWithKeywordAndCursor(
-            HttpServletRequest request,
-            AlcoholSearchRequestDto alcoholSearchRequestDto) {
-        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        int memberId = tokenService.getMemberId(token);
-
+    public ResponseEntity<AlcoholInfoWithPagingDto> getAlcoholIdListWithKeywordAndCursor(@RequestAttribute Integer memberId,
+                                                                                         AlcoholSearchRequestDto alcoholSearchRequestDto) {
         return new ResponseEntity<>(alcoholService.getAlcoholInfo(memberId, alcoholSearchRequestDto), HttpStatus.OK);
     }
 

--- a/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sullog.backend.auth.service.KakaoService;
@@ -11,9 +12,6 @@ import sullog.backend.member.entity.Member;
 import sullog.backend.member.entity.Token;
 import sullog.backend.auth.service.TokenService;
 import sullog.backend.member.service.MemberService;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 @RestController
 public class AuthController {
@@ -29,9 +27,7 @@ public class AuthController {
     }
 
     @GetMapping("/token/refresh")
-    public ResponseEntity<Void> refreshAuth(HttpServletRequest request) {
-        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        int memberId = tokenService.getMemberId(token);
+    public ResponseEntity<Void> refreshAuth(@RequestAttribute Integer memberId) {
         Token newToken = tokenService.generateToken(memberId, "USER");
 
         // response 생성

--- a/backend/src/main/java/sullog/backend/common/config/WebMvcConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package sullog.backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import sullog.backend.common.interceptor.MemberIdInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final MemberIdInterceptor memberIdInterceptor;
+
+    public WebMvcConfig(MemberIdInterceptor memberIdInterceptor) {
+        this.memberIdInterceptor = memberIdInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(memberIdInterceptor);
+    }
+}

--- a/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
+++ b/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
@@ -1,0 +1,27 @@
+package sullog.backend.common.interceptor;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import sullog.backend.auth.service.TokenService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class MemberIdInterceptor extends HandlerInterceptorAdapter {
+
+    private final TokenService tokenService;
+
+    public MemberIdInterceptor(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        Integer memberId = tokenService.getMemberId(token);
+        request.setAttribute("memberId", memberId);
+        return true;
+    }
+}

--- a/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
+++ b/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
@@ -2,14 +2,14 @@ package sullog.backend.common.interceptor;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 import sullog.backend.auth.service.TokenService;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
-public class MemberIdInterceptor extends HandlerInterceptorAdapter {
+public class MemberIdInterceptor implements HandlerInterceptor {
 
     private final TokenService tokenService;
 
@@ -18,7 +18,7 @@ public class MemberIdInterceptor extends HandlerInterceptorAdapter {
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
         Integer memberId = tokenService.getMemberId(token);
         request.setAttribute("memberId", memberId);

--- a/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
+++ b/backend/src/main/java/sullog/backend/common/interceptor/MemberIdInterceptor.java
@@ -20,6 +20,9 @@ public class MemberIdInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (null == token) { // permitAll로 처리되는 요청은 jwtToken값을 실어보내지 않으므로, 방어로직 추가
+            return true;
+        }
         Integer memberId = tokenService.getMemberId(token);
         request.setAttribute("memberId", memberId);
         return true;

--- a/backend/src/main/java/sullog/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/sullog/backend/member/controller/MemberController.java
@@ -12,39 +12,33 @@ import sullog.backend.member.dto.response.RecentSearchHistoryDto;
 public class MemberController {
 
     private final MemberService memberService;
-    private final TokenService tokenService;
 
-    public MemberController(MemberService memberService, TokenService tokenService) {
+    public MemberController(MemberService memberService) {
         this.memberService = memberService;
-        this.tokenService = tokenService;
     }
 
     @GetMapping("/me/recent-search-history")
-    public ResponseEntity<RecentSearchHistoryDto> getRecentSearchHistory(@RequestHeader String authorization) {
-        int memberId = tokenService.getMemberId(authorization);
+    public ResponseEntity<RecentSearchHistoryDto> getRecentSearchHistory(@RequestAttribute Integer memberId) {
         return new ResponseEntity<>(memberService.getRecentSearchHistory(memberId), HttpStatus.OK);
     }
 
     @DeleteMapping("/me/recent-search-history/{keyword}")
-    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestHeader String authorization,
+    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestAttribute Integer memberId,
                                                             @PathVariable String keyword) {
-        int memberId = tokenService.getMemberId(authorization);
         memberService.removeSearchKeyword(memberId, keyword);
 
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/me/recent-search-history")
-    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestHeader String authorization) {
-        int memberId = tokenService.getMemberId(authorization);
+    public ResponseEntity<Void> removeSpecificSearchKeyword(@RequestAttribute Integer memberId) {
         memberService.clearRecentSearchKeyword(memberId);
 
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMember(@RequestHeader String authorization) {
-        int memberId = tokenService.getMemberId(authorization);
+    public ResponseEntity<Void> deleteMember(@RequestAttribute Integer memberId) {
         memberService.deleteMember(memberId);
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -24,25 +24,20 @@ import java.util.stream.Collectors;
 @RequestMapping("/records")
 public class RecordController {
 
-    private final TokenService tokenService;
     private final RecordService recordService;
     private final ImageUploadService imageUploadService;
     private final AlcoholService alcoholService;
 
-    public RecordController(TokenService tokenService, RecordService recordService, ImageUploadService imageUploadService, AlcoholService alcoholService) {
-        this.tokenService = tokenService;
+    public RecordController(RecordService recordService, ImageUploadService imageUploadService, AlcoholService alcoholService) {
         this.recordService = recordService;
         this.imageUploadService = imageUploadService;
         this.alcoholService = alcoholService;
     }
 
     @PostMapping
-    public ResponseEntity<Void> saveRecord(@RequestHeader(name="Authorization") String accessToken,
+    public ResponseEntity<Void> saveRecord(@RequestAttribute Integer memberId,
                         @RequestPart(required = false) List<MultipartFile> photoList,
                         @RequestPart("recordInfo") RecordSaveRequestDto requestDto) {
-        // 작성자 조회
-        int memberId = tokenService.getMemberId(accessToken);
-
         // 이미지 저장
         List<String> photoPathList = imageUploadService.uploadImageList(photoList);
 
@@ -53,9 +48,7 @@ public class RecordController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<List<RecordMetaDto>> getRecords(@RequestHeader(name="Authorization") String accessToken) {
-        int memberId = tokenService.getMemberId(accessToken);
-
+    public ResponseEntity<List<RecordMetaDto>> getRecords(@RequestAttribute Integer memberId) {
         List<RecordMetaDto> recordMetaDtoList = recordService.getRecordMetasByMemberId(memberId).stream()
                 .map(RecordMetaWithAlcoholInfoDto::toResponseDto)
                 .collect(Collectors.toList());
@@ -80,11 +73,9 @@ public class RecordController {
     }
 
     @GetMapping("/me/search")
-    public ResponseEntity<RecordMetaListWithPagingDto> searchRecords(@RequestHeader(name="Authorization") String accessToken,
+    public ResponseEntity<RecordMetaListWithPagingDto> searchRecords(@RequestAttribute Integer memberId,
                                                                      RecordSearchParamDto recordSearchParamDto) {
-        int memberId = tokenService.getMemberId(accessToken);
-
-        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByCondition(memberId, recordSearchParamDto);
+       List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByCondition(memberId, recordSearchParamDto);
 
         RecordMetaListWithPagingDto recordMetaListWithPagingDto = RecordMetaListWithPagingDto.builder()
                 .recordMetaList(recordMetaWithAlcoholInfoList.stream()


### PR DESCRIPTION
## 개요
- api에서 사용자 조회는 token기반으로 이뤄지기 때문에, 컨트롤러 메서드 상단에는 항상 동일한 로직이 반복되고 있음
- 리팩토링을 통해 token기반으로 memberId 추출하는 곳을 일원화하고, 쓰는쪽에서는 값을 바로 쓸 수 있도록 수정

## 작업사항
- HandlerInterceptor 인터페이스를 구현해서 jwt token으로 memberId 를 조회하여, 그 값을 request attribute에 추가
   - WebMvcConfiguration에 해당 인터셉터 추가

## 변경로직
- 헤더에서 `Authorization`필드를 읽어서 token -> memberId 조회하던 로직을 제거하고, @RequestAttribute Integer memberId로 전달받도록 수정

## 참고
aop로 분리할지, 인터셉터로 분리할지 고민했는데, 해당 기능은 http request 요청 처리 전에 항상 수행되어야 하는 작업이므로 HandlerInterceptor 로 분리하였습니다! 
[관심사 분리?의 유사한 기능들 차이점 참고](https://goddaehee.tistory.com/154#:~:text=AOP%EC%9D%98%20Advice%EC%99%80%20HandlerInterceptor,%EB%A5%BC%20%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0%EB%A1%9C%20%EC%82%AC%EC%9A%A9%ED%95%9C%EB%8B%A4.&text=AOP%EB%8A%94%20%EC%8B%AC%EC%98%A4%ED%95%B4%EC%84%9C%20%EC%A0%9C%EB%8C%80%EB%A1%9C%20%EB%94%B0%EB%A1%9C%20%EC%A0%95%EB%A6%AC%20%ED%95%B4%EC%95%BC%20%ED%95%A0%20%EA%B2%83%EA%B0%99%EB%8B%A4.)
