### PR TITLE
클라이언트 환경별 url에 따라 cors 대응

### DIFF
--- a/backend/src/main/java/sullog/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package sullog.backend.common.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -32,10 +33,8 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
-    @Value("${spring.profiles.active}")
-    private String activeVersion; // 현재 local or alpha
-
-    private final String LIVE_VERSION = "live";
+    @Value("#{'${client-domains}'.split(',')}")
+    private List<String> clientDomains;
 
     public SecurityConfig(CustomOAuth2UserService oAuth2UserService, OAuth2SuccessHandler successHandler, JwtAuthFilter jwtAuthFilter, JwtAccessDeniedHandler jwtAccessDeniedHandler, JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
         this.oAuth2UserService = oAuth2UserService;
@@ -85,8 +84,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        String frontDomain = activeVersion.equals(LIVE_VERSION) ? "https://sullog.vercel.app" : "http://localhost:3000";
-        configuration.setAllowedOrigins(Collections.singletonList(frontDomain));
+        configuration.setAllowedOrigins(clientDomains);
         configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE","OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setExposedHeaders(List.of("Refresh", HttpHeaders.AUTHORIZATION));

--- a/backend/src/main/resources/application-alpha.yml
+++ b/backend/src/main/resources/application-alpha.yml
@@ -25,3 +25,6 @@ logging:
       resultset: off
       connection: off
   config: classpath:log4j2-alpha.yml
+
+# CORS 이슈 대응
+client-domains: "http://localhost:3000"

--- a/backend/src/main/resources/application-live.yml
+++ b/backend/src/main/resources/application-live.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: "classpath:oauth-live.yml"
   datasource:
     driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
     jdbc-url: ENC(eP1NIZrxh2ECdO2BRGC8eQyHt8vMyZSSyyRjYIW0FCr8hfoRUQi+EtS6TR5gNr5p0FksqCEX6p6UZvGcuVfWA4R1HR7uKEnKIT6gb2f0JtyH0Tz5XWBfJlDOP9cUAY4Xr7Du5A5l3y7D28lUjVZ4oM0+vIKZIYzkCyl8POg+oagDpAPxau2aOsDtFRuMNRJ7TdEB4ahZyU+F1DnA7p1pSEMikImCnNHGAl55TNd5Uovw+C7qSfb1F+roNi8danc+y/n/v7D0iEA=)
@@ -13,8 +15,10 @@ spring:
       #        idle-timeout: 600000
       #        max-lifetime: 1800000
       max-lifetime: 6000 # Possibly consider using a shorter maxLifetime value.(10000 => 6000)
+
 mybatis:
   mapper-locations: "classpath:/mapper/**/*.xml"
+
 logging:
   level:
     jdbc:
@@ -25,3 +29,5 @@ logging:
       resultset: off
       connection: off
 
+# CORS 이슈 대응
+client-domains: "https://sullog-client.vercel.app,https://sullog-dev.vercel.app"

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -27,3 +27,6 @@ logging:
       connection: off
   config: classpath:log4j2-local.yml
 
+# CORS 이슈 대응
+client-domains: "http://localhost:3000"
+

--- a/backend/src/main/resources/oauth-live.yml
+++ b/backend/src/main/resources/oauth-live.yml
@@ -1,0 +1,20 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: 209bdcaaebd1d90d002f358651d8ef4b
+            redirect-uri: https://sullog-client.vercel.app/login
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id


### PR DESCRIPTION
## 개요
- #76 에 따라서, cors 도메인도 환경별로 달라짐

## 작업사항
- 클라이언트 기준 local, alpha / dev / production 에 따라서 cors 도메인을 yml 파일에 명세
- cors빈 등록 시 application-{환경}.yml 에서 `client-domains` 읽어와 setAllowedOrigins 메서드에 값 셋팅 
- live환경 oauth yml파일이 없어서 추가

## 변경로직
- cors 빈 등록 시 클라이언트 도메인을 하드코딩해뒀는데, 외부 파일로 분리

## 참고
- 클라이언트의 dev, production은 서버기준 live를 바라보게 할 예정이므로, application-live에 2개의 클라이언트 도메인을 지정해뒀음
- ouath-live.yml의 redirect uri는 beta와 production url을 둘다 설정할 수 없어서, 클라이언트에게 양해를 구하고 beta 환경에서도 production url로 redirecturi를 넘기게끔 설정해달라고 해야함

