### PR TITLE
feat: 주류 도메인에 주종 필드 추가 작업

### DIFF
--- a/backend/src/main/java/sullog/backend/alcohol/dto/response/AlcoholInfoDto.java
+++ b/backend/src/main/java/sullog/backend/alcohol/dto/response/AlcoholInfoDto.java
@@ -11,6 +11,8 @@ public class AlcoholInfoDto {
 
     private String brandName;
 
+    private String alcoholType;
+
     private double alcoholPercent;
 
     private String productionLocation;
@@ -27,6 +29,10 @@ public class AlcoholInfoDto {
 
     public String getBrandName() {
         return brandName;
+    }
+
+    public String getAlcoholType() {
+        return alcoholType;
     }
 
     public double getAlcoholPercent() {

--- a/backend/src/main/java/sullog/backend/alcohol/dto/table/AlcoholWithBrandDto.java
+++ b/backend/src/main/java/sullog/backend/alcohol/dto/table/AlcoholWithBrandDto.java
@@ -16,6 +16,8 @@ public class AlcoholWithBrandDto {
 
     private String alcoholName;
 
+    private String alcoholType;
+
     private double alcoholPercent;
 
     private String productionLocation;
@@ -46,6 +48,10 @@ public class AlcoholWithBrandDto {
 
     public String getAlcoholName() {
         return alcoholName;
+    }
+
+    public String getAlcoholType() {
+        return alcoholType;
     }
 
     public double getAlcoholPercent() {
@@ -103,6 +109,7 @@ public class AlcoholWithBrandDto {
     public AlcoholInfoDto toAlcoholInfoDto() {
         return AlcoholInfoDto.builder()
                 .alcoholName(alcoholName)
+                .alcoholType(alcoholType)
                 .alcoholPercent(alcoholPercent)
                 .alcoholTag(alcoholTag)
                 .brandName(brandName)

--- a/backend/src/main/java/sullog/backend/alcohol/entity/Alcohol.java
+++ b/backend/src/main/java/sullog/backend/alcohol/entity/Alcohol.java
@@ -15,6 +15,8 @@ public class Alcohol extends BaseEntity {
 
     private String name;
 
+    private String alcoholType;
+
     private double alcoholPercent;
 
     private String productionLocation;
@@ -31,6 +33,10 @@ public class Alcohol extends BaseEntity {
 
     public String getName() {
         return name;
+    }
+
+    public String getAlcoholType() {
+        return alcoholType;
     }
 
     public double getAlcoholPercent() {
@@ -62,6 +68,7 @@ public class Alcohol extends BaseEntity {
             int alcoholId,
             int brandId,
             String name,
+            String alcoholType,
             double alcoholPercent,
             String productionLocation,
             double productionLatitude,
@@ -74,6 +81,7 @@ public class Alcohol extends BaseEntity {
         this.alcoholId = alcoholId;
         this.brandId = brandId;
         this.name = name;
+        this.alcoholType = alcoholType;
         this.alcoholPercent = alcoholPercent;
         this.productionLocation = productionLocation;
         this.productionLatitude = productionLatitude;

--- a/backend/src/main/java/sullog/backend/alcohol/service/AlcoholService.java
+++ b/backend/src/main/java/sullog/backend/alcohol/service/AlcoholService.java
@@ -42,19 +42,7 @@ public class AlcoholService {
                 alcoholSearchRequestDto.getLimit());
 
         alcoholWithBrandDtoList
-                .forEach(dto -> {
-                    AlcoholInfoDto alcoholInfoDto = AlcoholInfoDto.builder()
-                            .alcoholName(dto.getAlcoholName())
-                            .alcoholPercent(dto.getAlcoholPercent())
-                            .alcoholTag(dto.getAlcoholTag())
-                            .brandName(dto.getBrandName())
-                            .productionLatitude(dto.getProductionLatitude())
-                            .productionLongitude(dto.getProductionLongitude())
-                            .productionLocation(dto.getProductionLocation())
-                            .alcoholPercent(dto.getAlcoholPercent())
-                            .build();
-                    alcoholInfoDtoList.add(alcoholInfoDto);
-                });
+                .forEach(dto -> alcoholInfoDtoList.add(dto.toAlcoholInfoDto()));
 
         int cursor = 0;
         if (alcoholInfoDtoList.size() > 0) {

--- a/backend/src/main/resources/mapper/alcohol/AlcoholMapper.xml
+++ b/backend/src/main/resources/mapper/alcohol/AlcoholMapper.xml
@@ -8,6 +8,7 @@
         <result property="alcoholId" column="alcohol_id"/>
         <result property="brandId" column="brand_id"/>
         <result property="alcoholName" column="alcohol_name"/>
+        <result property="alcoholType" column="alcohol_type"/>
         <result property="alcoholPercent" column="alcohol_percent"/>
         <result property="productionLocation" column="production_location"/>
         <result property="productionLatitude" column="production_latitude"/>
@@ -32,6 +33,7 @@
         SELECT a.alcohol_id           AS alcohol_id,
                a.brand_id             AS brand_id,
                a.name                 AS alcohol_name,
+               a.alcohol_type         AS alcohol_type,
                a.alcohol_percent      AS alcohol_percent,
                a.production_location  AS production_location,
                a.production_latitude  AS production_latitude,
@@ -55,6 +57,7 @@
         SELECT a.alcohol_id           AS alcohol_id,
                 a.brand_id             AS brand_id,
                 a.name                 AS alcohol_name,
+                a.alcohol_type         AS alcohol_type,
                 a.alcohol_percent      AS alcohol_percent,
                 a.production_location  AS production_location,
                 a.production_latitude  AS production_latitude,

--- a/backend/src/main/resources/static/docs/api-doc.html
+++ b/backend/src/main/resources/static/docs/api-doc.html
@@ -1138,8 +1138,8 @@ Content-Type: application/json
 </div>
 <div class="sect2">
 <h3 id="_특정_사용자의_전통주_경험_조회">특정 사용자의 전통주 경험 조회</h3>
-<div class="sect4">
-<h5 id="_request_10">Request</h5>
+<div class="sect3">
+<h4 id="_request_10">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me HTTP/1.1
@@ -1148,8 +1148,8 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
-<div class="sect4">
-<h5 id="_response_10">Response</h5>
+<div class="sect3">
+<h4 id="_response_10">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1262,8 +1262,8 @@ Content-Length: 1061
 </div>
 <div class="sect2">
 <h3 id="_경험기록_id_기반_전통주_경험_단건_조회">경험기록 id 기반 전통주 경험 단건 조회</h3>
-<div class="sect4">
-<h5 id="_request_11">Request</h5>
+<div class="sect3">
+<h4 id="_request_11">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/1 HTTP/1.1
@@ -1290,8 +1290,8 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 </div>
-<div class="sect4">
-<h5 id="_response_11">Response</h5>
+<div class="sect3">
+<h4 id="_response_11">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1466,8 +1466,8 @@ Content-Length: 794
 </div>
 <div class="sect2">
 <h3 id="_특정_사용자의_키워드_기반_경험기록_검색">특정 사용자의 키워드 기반 경험기록 검색</h3>
-<div class="sect4">
-<h5 id="_request_12">Request</h5>
+<div class="sect3">
+<h4 id="_request_12">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me/search?cursor=1&amp;keyword=keyword&amp;limit=2 HTTP/1.1
@@ -1502,8 +1502,8 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 </div>
-<div class="sect4">
-<h5 id="_response_12">Response</h5>
+<div class="sect3">
+<h4 id="_response_12">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1631,8 +1631,8 @@ Content-Length: 834
 </div>
 <div class="sect2">
 <h3 id="_경험_피드">경험 피드</h3>
-<div class="sect4">
-<h5 id="_request_13">Request</h5>
+<div class="sect3">
+<h4 id="_request_13">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records?cursor=1&amp;limit=2 HTTP/1.1
@@ -1663,8 +1663,8 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 </div>
-<div class="sect4">
-<h5 id="_response_13">Response</h5>
+<div class="sect3">
+<h4 id="_response_13">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -2101,7 +2101,7 @@ Content-Length: 877
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-23 22:42:54 +0900
+Last updated 2023-04-23 22:51:51 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
+++ b/backend/src/test/java/sullog/backend/alcohol/controller/AlcoholControllerTest.java
@@ -71,6 +71,7 @@ class AlcoholControllerTest {
 
         AlcoholInfoDto alcoholInfoDto = AlcoholInfoDto.builder()
                 .alcoholName("전통주 샘플")
+                .alcoholType("기타")
                 .alcoholTag("{}")
                 .alcoholPercent(10.0)
                 .productionLocation("서울시 광진구")
@@ -98,6 +99,7 @@ class AlcoholControllerTest {
                                 responseFields( // response 필드 정보 입력
                                         fieldWithPath("alcoholName").type(JsonFieldType.STRING).description("전통주 이름"),
                                         fieldWithPath("brandName").type(JsonFieldType.STRING).description("브랜드 이름"),
+                                        fieldWithPath("alcoholType").type(JsonFieldType.STRING).description("주종"),
                                         fieldWithPath("alcoholPercent").type(JsonFieldType.NUMBER).description("도수"),
                                         fieldWithPath("productionLocation").type(JsonFieldType.STRING).description("생산지 주소"),
                                         fieldWithPath("productionLatitude").type(JsonFieldType.NUMBER).description("생산지 위도"),
@@ -116,6 +118,7 @@ class AlcoholControllerTest {
         AlcoholInfoDto alcoholInfoDto = AlcoholInfoDto.builder()
                 .alcoholName("전통주 샘플")
                 .alcoholTag("{}")
+                .alcoholType("기타")
                 .alcoholPercent(10.0)
                 .productionLocation("서울시 광진구")
                 .productionLongitude(0.0)
@@ -168,6 +171,7 @@ class AlcoholControllerTest {
                                         fieldWithPath("alcoholInfoDtoList").type(JsonFieldType.ARRAY).description("전통주 리스트"),
                                         fieldWithPath("alcoholInfoDtoList[].alcoholName").type(JsonFieldType.STRING).description("전통주 명"),
                                         fieldWithPath("alcoholInfoDtoList[].brandName").type(JsonFieldType.STRING).description("브랜드 명"),
+                                        fieldWithPath("alcoholInfoDtoList[].alcoholType").type(JsonFieldType.STRING).description("주종"),
                                         fieldWithPath("alcoholInfoDtoList[].alcoholPercent").type(JsonFieldType.NUMBER).description("도수"),
                                         fieldWithPath("alcoholInfoDtoList[].productionLocation").type(JsonFieldType.STRING).description("생산지 주소"),
                                         fieldWithPath("alcoholInfoDtoList[].productionLatitude").type(JsonFieldType.NUMBER).description("생산지 위도"),

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -276,6 +276,7 @@ class RecordControllerTest {
                                 fieldWithPath("alcoholInfo").type(JsonFieldType.OBJECT).optional().description("전통주 정보"),
                                 fieldWithPath("alcoholInfo.brandName").description("전통주 브랜드 이름"),
                                 fieldWithPath("alcoholInfo.alcoholName").description("전통주 이름"),
+                                fieldWithPath("alcoholInfo.alcoholType").description("주종"),
                                 fieldWithPath("alcoholInfo.alcoholPercent").type(JsonFieldType.NUMBER).description("도수"),
                                 fieldWithPath("alcoholInfo.productionLocation").type(JsonFieldType.STRING).description("생산지 주소"),
                                 fieldWithPath("alcoholInfo.productionLatitude").type(JsonFieldType.NUMBER).description("생산지 위도"),


### PR DESCRIPTION
## 개요
- 주류 도메인에 주종 필드 추가 작업
- 참고 이슈: #86

## 작업사항
- Entity 및 Dto 수정
- 이에 따른 테스트 수정
- 이에 따른 API 독스 산출물 추가
- DB에 alcohol 테이블에 alcohol_type 컬럼 추가

## 기타
- 실제 각 주류 별 주종명을 json파일에서 찾아서 update하는 작업 필요(우선은 '기타'로 통일)
