### PR TITLE
fix: 경험 통계 조회 API 리스폰스에 사용자 정보 추가

### DIFF
--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -118,8 +118,8 @@ public class RecordController {
     }
 
     @GetMapping("/me/statistics")
-    public ResponseEntity<Map<String, Integer>> getMyRecordStatistics(@RequestAttribute Integer memberId) {
-        Map<String, Integer> recordStatisticMap = recordStatisticService.getRecordStatistics(memberId);
-        return new ResponseEntity<>(recordStatisticMap, HttpStatus.OK);
+    public ResponseEntity<RecordStatistics> getMyRecordStatistics(@RequestAttribute Integer memberId) {
+        RecordStatistics recordStatistics = recordStatisticService.getRecordStatistics(memberId);
+        return new ResponseEntity<>(recordStatistics, HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/sullog/backend/record/dto/response/RecordStatistics.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/RecordStatistics.java
@@ -1,0 +1,33 @@
+package sullog.backend.record.dto.response;
+
+import lombok.Builder;
+
+import java.util.Map;
+
+@Builder
+public class RecordStatistics {
+
+    private Integer memberId;
+
+    private String email;
+
+    private String nickname;
+
+    private Map<String, Integer> recordStatisticsMap;
+
+    public Integer getMemberId() {
+        return memberId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public Map<String, Integer> getRecordStatisticsMap() {
+        return recordStatisticsMap;
+    }
+}

--- a/backend/src/main/java/sullog/backend/record/service/RecordStatisticService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordStatisticService.java
@@ -1,28 +1,41 @@
 package sullog.backend.record.service;
 
 import org.springframework.stereotype.Service;
+import sullog.backend.member.entity.Member;
+import sullog.backend.member.mapper.MemberMapper;
+import sullog.backend.record.dto.response.RecordStatistics;
 import sullog.backend.record.mapper.RecordMapper;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Service
 public class RecordStatisticService {
 
-    RecordMapper recordMapper;
+    private RecordMapper recordMapper;
 
-    public RecordStatisticService(RecordMapper recordMapper) {
+    private MemberMapper memberMapper;
+
+    public RecordStatisticService(RecordMapper recordMapper, MemberMapper memberMapper) {
         this.recordMapper = recordMapper;
+        this.memberMapper = memberMapper;
     }
 
-    public  Map<String, Integer> getRecordStatistics(Integer memberId) {
+    public RecordStatistics getRecordStatistics(Integer memberId) {
+        Member member = memberMapper.selectMemberById(memberId);
+
         Map<String, Integer> alcoholTypeStatisticMap = new HashMap<>();
         recordMapper.selectAlcoholTypeList(memberId)
                 .forEach(alcoholType -> {
                     Integer count = alcoholTypeStatisticMap.getOrDefault(alcoholType, 0);
                     alcoholTypeStatisticMap.put(alcoholType, count + 1);
                 });
-        return alcoholTypeStatisticMap;
+
+        return RecordStatistics.builder()
+                .memberId(memberId)
+                .email(member.getEmail())
+                .nickname(member.getNickName())
+                .recordStatisticsMap(alcoholTypeStatisticMap)
+                .build();
     }
 }

--- a/backend/src/main/resources/static/docs/api-doc.html
+++ b/backend/src/main/resources/static/docs/api-doc.html
@@ -1830,12 +1830,17 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 56
+Content-Length: 172
 
 {
-  "막걸리" : 2,
-  "기타" : 3,
-  "과실주" : 5
+  "memberId" : 1,
+  "email" : "abc@naver.com",
+  "nickname" : "술로그123",
+  "recordStatisticsMap" : {
+    "막걸리" : 2,
+    "기타" : 3,
+    "과실주" : 5
+  }
 }</code></pre>
 </div>
 </div>
@@ -1854,9 +1859,29 @@ Content-Length: 56
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>*</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">주종 명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recordStatisticsMap</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주종 명 별 통계 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recordStatisticsMap.*</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주종 명 별 누적 숫자</p></td>
 </tr>
 </tbody>
 </table>
@@ -2166,7 +2191,7 @@ Content-Length: 56
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-04-30 23:08:48 +0900
+Last updated 2023-04-30 23:20:48 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -21,6 +21,7 @@ import sullog.backend.alcohol.service.AlcoholService;
 import sullog.backend.member.config.jwt.JwtAuthFilter;
 import sullog.backend.auth.service.TokenService;
 import sullog.backend.record.dto.request.RecordSearchParamDto;
+import sullog.backend.record.dto.response.RecordStatistics;
 import sullog.backend.record.dto.table.AllRecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.FlavorDetail;
@@ -437,8 +438,13 @@ class RecordControllerTest {
         responseMap.put("기타", 3);
         responseMap.put("막걸리", 2);
         responseMap.put("과실주", 5);
-        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoDtos = makeMockingDBResponse();
-        doReturn(responseMap).when(recordStatisticService).getRecordStatistics(memberId);
+        RecordStatistics recordStatistics = RecordStatistics.builder()
+                .memberId(memberId)
+                .email("abc@naver.com")
+                .nickname("술로그123")
+                .recordStatisticsMap(responseMap)
+                .build();
+        doReturn(recordStatistics).when(recordStatisticService).getRecordStatistics(memberId);
         when(tokenService.getMemberId(anyString())).thenReturn(memberId);
 
         // when, then
@@ -452,7 +458,11 @@ class RecordControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         responseFields(
-                                fieldWithPath("*").description("주종 명")
+                                fieldWithPath("memberId").description("사용자 ID"),
+                                fieldWithPath("email").description("이메일"),
+                                fieldWithPath("nickname").description("닉네임"),
+                                fieldWithPath("recordStatisticsMap").type(JsonFieldType.OBJECT).description("주종 명 별 통계 정보"),
+                                fieldWithPath("recordStatisticsMap.*").description("주종 명 별 누적 숫자")
                         ))
                 );
 


### PR DESCRIPTION
## 개요
- #85 이슈에 따른 수정

## 작업사항
- 경험 통계 조회 시 사용자 정보도 같이 조회할 수 있도록 수정

## 변경로직
- 기존 그냥 Map 리턴하던 방식에서 리스폰스 객체로 감싸 Map과 사용자 정보를 담도록 수정
