### PR TITLE
경험 저장 API 요청 시 새로 추가한 데이터에 접근할 수 있도록 수정

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -130,6 +130,7 @@ include::{snippets}/record/save-record/request-part-recordInfo-fields.adoc[]
 
 ==== Response
 include::{snippets}/record/save-record/http-response.adoc[]
+include::{snippets}/record/save-record/response-headers.adoc[]
 
 === 특정 사용자의 전통주 경험 조회
 ==== Request

--- a/backend/src/main/java/sullog/backend/record/service/RecordService.java
+++ b/backend/src/main/java/sullog/backend/record/service/RecordService.java
@@ -1,9 +1,7 @@
 package sullog.backend.record.service;
 
 import org.springframework.stereotype.Service;
-import sullog.backend.member.mapper.MemberMapper;
 import sullog.backend.record.dto.request.RecordSearchParamDto;
-import sullog.backend.record.dto.response.AllRecordMetaListWithPaging;
 import sullog.backend.record.dto.table.AllRecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.dto.table.RecordMetaWithAlcoholInfoDto;
 import sullog.backend.record.entity.Record;
@@ -20,8 +18,9 @@ public class RecordService {
         this.recordMapper = recordMapper;
     }
 
-    public void saveRecord(Record record) {
+    public Integer saveRecord(Record record) {
         recordMapper.insertRecord(record);
+        return record.getRecordId();
     }
 
     public List<RecordMetaWithAlcoholInfoDto> getRecordMetasByMemberId(int memberId) {

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -4,7 +4,7 @@
 
 <mapper namespace="sullog.backend.record.mapper.RecordMapper">
 
-    <insert id="insertRecord" parameterType="sullog.backend.record.entity.Record">
+    <insert id="insertRecord" parameterType="sullog.backend.record.entity.Record" useGeneratedKeys="true" keyProperty="recordId">
         INSERT INTO record
         (
             member_id,

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -44,6 +45,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -115,6 +117,7 @@ class RecordControllerTest {
 
         when(imageUploadService.uploadImageList(any())).thenReturn(List.of("test1.jpg", "test2.jpg"));
         when(tokenService.getMemberId(anyString())).thenReturn(memberId);
+        when(recordService.saveRecord(any())).thenReturn(5);
 
         // when, then
         mockMvc.perform(multipart("/records")
@@ -146,7 +149,10 @@ class RecordControllerTest {
                                 fieldWithPath("textureScore").type(JsonFieldType.NUMBER).description("감촉점수 (1~5)"),
                                 fieldWithPath("description").type(JsonFieldType.STRING).description("상세 내용"),
                                 fieldWithPath("experienceDate").type(JsonFieldType.STRING).description("경험 날짜")
-                        ))
+                        )),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.LOCATION).description("방금 저장된 경험기록에 접근할 수 있는 url")
+                        )
                 ));
     }
 


### PR DESCRIPTION
## 개요
- #98 대응

## 작업사항
경험 저장 시 방금 저장한 데이터에 접근할 수 있도록 관련 로직 수정
- record_id 컬럼은 auto increment 설정이 되어 있어서, mybatis의 `useGeneratedKeys` 기능을 이용해서 record_id에 셋팅된 값 읽어옴
  - https://myeongdev.tistory.com/38 참고 

api resonse 수정
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201 을 참고하여 새로 생성된 데이터에 접근할 수 있는 uri를 location 필드에 셋팅

## 변경 로직
경험 저장 api `POST /records` response 수정
- as-is: 특별히 값을 넘겨주지 않음
- to-be: http header location 필드에 방금 저장한 경험에 접근할 수 있는 url 값 셋팅 