### PR TITLE
feat: 예외 응답 객체 작성

### DIFF
--- a/backend/src/main/java/sullog/backend/alcohol/error/AlcoholControllerAdvice.java
+++ b/backend/src/main/java/sullog/backend/alcohol/error/AlcoholControllerAdvice.java
@@ -1,18 +1,20 @@
 package sullog.backend.alcohol.error;
 
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import sullog.backend.alcohol.error.exception.AlcoholException;
-import sullog.backend.common.error.ErrorCode;
+import sullog.backend.common.error.response.ErrorResponse;
 
+@Slf4j
 @RestControllerAdvice
 public class AlcoholControllerAdvice {
 
     @ExceptionHandler(AlcoholException.class)
-    ResponseEntity<String> exceptionHandler(AlcoholException e) {
-        return new ResponseEntity<>(e.getErrorCode().toString(), HttpStatus.BAD_REQUEST);
+    ResponseEntity<ErrorResponse> exceptionHandler(AlcoholException e) {
+        log.error("AlcoholException 예외 발생", e);
+        return ErrorResponse.toResponseEntity(e);
     }
 
 }

--- a/backend/src/main/java/sullog/backend/alcohol/error/exception/AlcoholException.java
+++ b/backend/src/main/java/sullog/backend/alcohol/error/exception/AlcoholException.java
@@ -1,18 +1,19 @@
 package sullog.backend.alcohol.error.exception;
 
 import sullog.backend.common.error.ErrorCode;
+import sullog.backend.common.error.exception.BusinessException;
 
-public class AlcoholException extends RuntimeException {
+public class AlcoholException extends BusinessException {
 
     private final ErrorCode errorCode;
 
     public AlcoholException(ErrorCode errorCode, String message) {
-        super(message);
+        super(errorCode, message);
         this.errorCode = errorCode;
     }
 
     public AlcoholException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
+        super(errorCode);
         this.errorCode = errorCode;
     }
 

--- a/backend/src/main/java/sullog/backend/common/error/CommonControllerAdvice.java
+++ b/backend/src/main/java/sullog/backend/common/error/CommonControllerAdvice.java
@@ -1,11 +1,11 @@
 package sullog.backend.common.error;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import sullog.backend.common.error.exception.CommonException;
+import sullog.backend.common.error.exception.BusinessException;
+import sullog.backend.common.error.response.ErrorResponse;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -15,15 +15,15 @@ import java.io.StringWriter;
 public class CommonControllerAdvice {
 
     @ExceptionHandler(Exception.class)
-    ResponseEntity<String> exceptionHandler(Exception e) {
-        log.error("예외 발생", e);
-        return new ResponseEntity<>(getSystemErrorMessage(e), HttpStatus.BAD_REQUEST);
+    ResponseEntity<ErrorResponse> exceptionHandler(Exception e) {
+        log.error("미처리 예외 발생", e);
+        return ErrorResponse.toResponseEntity(e);
     }
 
-    @ExceptionHandler(CommonException.class)
-    ResponseEntity<String> commonExceptionHandler(CommonException e) {
-        log.error("예외 발생", e);
-        return new ResponseEntity<>(e.getErrorCode().toString(), HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(BusinessException.class)
+    ResponseEntity<ErrorResponse> businessExceptionHandler(BusinessException e) {
+        log.error("비즈니스 예외 발생", e);
+        return ErrorResponse.toResponseEntity(e);
     }
 
     private String getSystemErrorMessage(Exception e) {

--- a/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
+++ b/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
 
     // Common
     UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "C001", "Unknown Error"),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "Server Error"),
 
 
     // Member

--- a/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
+++ b/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // Common
-    UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "C001", "???"),
+    UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "C001", "Unknown Error"),
 
 
     // Member
@@ -15,13 +15,13 @@ public enum ErrorCode {
 
     private final HttpStatus status;
 
-    private final String errorCode;
+    private final String code;
 
     private final String message;
 
-    ErrorCode(HttpStatus status, String errorCode, String message) {
+    ErrorCode(HttpStatus status, String code, String message) {
         this.status = status;
-        this.errorCode = errorCode;
+        this.code = code;
         this.message = message;
     }
 
@@ -29,8 +29,8 @@ public enum ErrorCode {
         return status;
     }
 
-    public String getErrorCode() {
-        return errorCode;
+    public String getCode() {
+        return code;
     }
 
     public String getMessage() {
@@ -41,7 +41,7 @@ public enum ErrorCode {
     public String toString() {
         return "ErrorCode{" +
                 "status=" + status +
-                ", errorCode='" + errorCode + '\'' +
+                ", code='" + code + '\'' +
                 ", message='" + message + '\'' +
                 '}';
     }

--- a/backend/src/main/java/sullog/backend/common/error/exception/BusinessException.java
+++ b/backend/src/main/java/sullog/backend/common/error/exception/BusinessException.java
@@ -2,16 +2,16 @@ package sullog.backend.common.error.exception;
 
 import sullog.backend.common.error.ErrorCode;
 
-public class CommonException extends RuntimeException {
+public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public CommonException(ErrorCode errorCode, String message) {
+    public BusinessException(ErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
     }
 
-    public CommonException(ErrorCode errorCode) {
+    public BusinessException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
+++ b/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
@@ -25,9 +25,9 @@ public class ErrorResponse {
         return new ResponseEntity<>(errorResponse, errorCode.getStatus());
     }
 
-    /** 사용자 미정의 예외 핸들링 */
+    /** 사용자 미정 예외 핸들링 */
     public static ResponseEntity<ErrorResponse> toResponseEntity(Exception e) {
-        ErrorCode errorCode = ErrorCode.UNKNOWN_ERROR;
+        ErrorCode errorCode = ErrorCode.SERVER_ERROR;
         ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), getSystemErrorMessage(e));
 
         return new ResponseEntity<>(errorResponse, errorCode.getStatus());

--- a/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
+++ b/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
@@ -1,0 +1,48 @@
+package sullog.backend.common.error.response;
+
+import lombok.ToString;
+import org.springframework.http.ResponseEntity;
+import sullog.backend.common.error.ErrorCode;
+import sullog.backend.common.error.exception.BusinessException;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+@ToString
+public class ErrorResponse {
+
+    private final String code; // 에러 코드 (ex. C001)
+
+    private final String message; // 에러 메시지
+
+    private final String systemErrorMessage; // e.printStackTrace
+
+    /** 사용자 정의 예외 핸들링 */
+    public static ResponseEntity<ErrorResponse> toResponseEntity(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), getSystemErrorMessage(e));
+
+        return new ResponseEntity<>(errorResponse, errorCode.getStatus());
+    }
+
+    /** 사용자 미정의 예외 핸들링 */
+    public static ResponseEntity<ErrorResponse> toResponseEntity(Exception e) {
+        ErrorCode errorCode = ErrorCode.UNKNOWN_ERROR;
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), getSystemErrorMessage(e));
+
+        return new ResponseEntity<>(errorResponse, errorCode.getStatus());
+    }
+
+    private ErrorResponse(String code, String message, String systemErrorMessage) {
+        this.code = code;
+        this.message = message;
+        this.systemErrorMessage = systemErrorMessage;
+    }
+
+    private static String getSystemErrorMessage(Exception e) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        return sw.toString();
+    }
+}

--- a/backend/src/main/java/sullog/backend/member/error/MemberControllerAdvice.java
+++ b/backend/src/main/java/sullog/backend/member/error/MemberControllerAdvice.java
@@ -1,17 +1,20 @@
 package sullog.backend.member.error;
 
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import sullog.backend.common.error.response.ErrorResponse;
 import sullog.backend.member.error.exception.MemberException;
 
+@Slf4j
 @RestControllerAdvice
 public class MemberControllerAdvice {
 
     @ExceptionHandler(MemberException.class)
-    ResponseEntity<String> exceptionHandler(MemberException e) {
-        return new ResponseEntity<>(e.getErrorCode().toString(), HttpStatus.BAD_REQUEST);
+    ResponseEntity<ErrorResponse> exceptionHandler(MemberException e) {
+        log.error("MemberException 발생", e);
+        return ErrorResponse.toResponseEntity(e);
     }
 
 }

--- a/backend/src/main/java/sullog/backend/member/error/exception/MemberException.java
+++ b/backend/src/main/java/sullog/backend/member/error/exception/MemberException.java
@@ -1,18 +1,19 @@
 package sullog.backend.member.error.exception;
 
 import sullog.backend.common.error.ErrorCode;
+import sullog.backend.common.error.exception.BusinessException;
 
-public class MemberException extends RuntimeException {
+public class MemberException extends BusinessException {
 
     private final ErrorCode errorCode;
 
     public MemberException(ErrorCode errorCode, String message) {
-        super(message);
+        super(errorCode, message);
         this.errorCode = errorCode;
     }
 
     public MemberException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
+        super(errorCode);
         this.errorCode = errorCode;
     }
 

--- a/backend/src/main/java/sullog/backend/record/error/RecordControllerAdvice.java
+++ b/backend/src/main/java/sullog/backend/record/error/RecordControllerAdvice.java
@@ -1,18 +1,27 @@
 package sullog.backend.record.error;
 
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import sullog.backend.member.error.exception.MemberException;
+import sullog.backend.common.error.response.ErrorResponse;
+import sullog.backend.record.error.exception.ImageUploadException;
 import sullog.backend.record.error.exception.RecordException;
 
+@Slf4j
 @RestControllerAdvice
 public class RecordControllerAdvice {
 
     @ExceptionHandler(RecordException.class)
-    ResponseEntity<String> exceptionHandler(RecordException e) {
-        return new ResponseEntity<>(e.getErrorCode().toString(), HttpStatus.BAD_REQUEST);
+    ResponseEntity<ErrorResponse> recordExceptionHandler(RecordException e) {
+        log.error("RecordException 예외 발생", e);
+        return ErrorResponse.toResponseEntity(e);
+    }
+
+    @ExceptionHandler(ImageUploadException.class)
+    ResponseEntity<ErrorResponse> imageUploadExceptionHandler(ImageUploadException e) {
+        log.error("ImageUploadException 예외 발생", e);
+        return ErrorResponse.toResponseEntity(e);
     }
 
 }

--- a/backend/src/main/java/sullog/backend/record/error/exception/RecordException.java
+++ b/backend/src/main/java/sullog/backend/record/error/exception/RecordException.java
@@ -1,18 +1,19 @@
 package sullog.backend.record.error.exception;
 
 import sullog.backend.common.error.ErrorCode;
+import sullog.backend.common.error.exception.BusinessException;
 
-public class RecordException extends RuntimeException {
+public class RecordException extends BusinessException {
 
     private final ErrorCode errorCode;
 
     public RecordException(ErrorCode errorCode, String message) {
-        super(message);
+        super(errorCode, message);
         this.errorCode = errorCode;
     }
 
     public RecordException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
+        super(errorCode);
         this.errorCode = errorCode;
     }
 


### PR DESCRIPTION
## 개요
- #67 작업
- 예외 응답 객체 작성(사용자 정의, 미정의 모두 포괄)

## 작업사항
- 사용자 정의 예외 클래스들은 모두 BusinessException이라는 최상위 사용자 정의 예외를 상속받도록 함
- ErrorResponse는 BusinessException을 파라미터로 받아 ResponseEntity클래스를 반환하도록 함
- 사용자 미정의 예외(ex. RuntimeException, Exception)의 경우 ResponseEnitty클래스로 변환할 때 ErrorCode.UNKNOWN_ERROR + e.printStackTrace() 이용
- ExceptionHandler에서 log.error 추가

## 변경로직
- 사용자 정의 예외 클래스 상속
    - as-is: 사용자 정의 예외 extends RuntimeException
    - to-be: 사용자 정의 예외 extends BusinessException
- ExceptionHandler
    - as-is: 콘솔 에러 로그(e.printStackTrace())만 리턴
    - to-be: 서버 정의 에러 코드, 에러 메시지, 콘솔 에러 로그 리턴
