### PR TITLE
fix: UNKNOWN_ERROR를 500으로 정의하도록 enum 변경

### DIFF
--- a/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
+++ b/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
@@ -5,8 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // Common
-    UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "C001", "Unknown Error"),
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "Server Error"),
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "Unknown Error"),
 
 
     // Member

--- a/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
+++ b/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
@@ -27,7 +27,7 @@ public class ErrorResponse {
 
     /** 사용자 미정 예외 핸들링 */
     public static ResponseEntity<ErrorResponse> toResponseEntity(Exception e) {
-        ErrorCode errorCode = ErrorCode.SERVER_ERROR;
+        ErrorCode errorCode = ErrorCode.UNKNOWN_ERROR;
         ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), getSystemErrorMessage(e));
 
         return new ResponseEntity<>(errorResponse, errorCode.getStatus());


### PR DESCRIPTION
## 개요
- UNKNOWN_ERROR를 500으로 정의하도록 enum 변경
- #106 코드 리뷰 코멘트 참고

## 작업사항
- 급하게 Merge하다보니 Enum에 SERVER_ERROR 필드를 추가했었으나 원래 PR 피드백대로 UNKNOWN_ERROR의 HttpStatus를 INTERNAL_SERVER_ERROR로 변경
- SERVER_ERROR 필드 삭제

## 변경로직
- UNKNOWN_ERROR의 HttpStatus 값
    - as-is: BAD_REQUEST
    - to-be: INTERNAL_SERVER_ERROR