### PR TITLE
예외 발생 시 json 데이터가 노출되도록 수정

### DIFF
--- a/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
+++ b/backend/src/main/java/sullog/backend/common/error/response/ErrorResponse.java
@@ -45,4 +45,16 @@ public class ErrorResponse {
         e.printStackTrace(pw);
         return sw.toString();
     }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getSystemErrorMessage() {
+        return systemErrorMessage;
+    }
 }


### PR DESCRIPTION
## 개요
- 예외 발생 시 white label 페이지 노출되고 있는데, json 데이터가 노출되도록 수정
    - 현재 예외 발생 시 응답방식
![image](https://github.com/sullog-official/sullog-server/assets/48347010/b22b79b1-bd36-4493-baa6-b5f49a83b6de)

## 작업사항
json 직렬화를 위해 getter 메서드 추가
![image](https://github.com/sullog-official/sullog-server/assets/48347010/df4ef9a0-afcd-4332-af08-bce82cc79875)

## 변경로직
- as-is: N/A
- to-be: ErrorResponse 에 getter 메서드 추가
