### PR TITLE
키워드 기반 경험 조회 시, 조회된 경험이 없을 경우, 응답 response 에 curosr 값 임의로 추가

### DIFF
--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -86,13 +86,18 @@ public class RecordController {
                                                                      RecordSearchParamDto recordSearchParamDto) {
        List<RecordMetaWithAlcoholInfoDto> recordMetaWithAlcoholInfoList = recordService.getRecordMetasByCondition(memberId, recordSearchParamDto);
 
+        int newCursor = 0;
+        if (recordMetaWithAlcoholInfoList.size() > 0) {
+            newCursor = recordMetaWithAlcoholInfoList.get(recordMetaWithAlcoholInfoList.size() - 1).getRecordId();
+        }
+
         RecordMetaListWithPagingDto recordMetaListWithPagingDto = RecordMetaListWithPagingDto.builder()
                 .recordMetaList(recordMetaWithAlcoholInfoList.stream()
                         .map(RecordMetaWithAlcoholInfoDto::toResponseDto)
                         .collect(Collectors.toList())
                 )
                 .pagingInfo(PagingInfoDto.builder()
-                        .cursor(recordMetaWithAlcoholInfoList.get(recordMetaWithAlcoholInfoList.size() - 1).getRecordId())
+                        .cursor(newCursor)
                         .limit(recordSearchParamDto.getLimit())
                         .build()
                 )

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -361,7 +361,7 @@ class RecordControllerTest {
                         preprocessResponse(prettyPrint()),
                         requestParameters( // path 파라미터 정보 입력
                                 parameterWithName("keyword").description("검색 키워드"),
-                                parameterWithName("cursor").description("마지막으로 조회한 경험기록 id(최초 조회 시 null)"),
+                                parameterWithName("cursor").description("마지막으로 조회한 경험기록 id. 최초 조회시에는 이 파라미터를 포함하지 않고, 두 번째 요청부터 포함해야 합니다."),
                                 parameterWithName("limit").description("한번에 조회해올 데이터 갯수")
                         ),
                         responseFields(
@@ -412,7 +412,7 @@ class RecordControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestParameters( // path 파라미터 정보 입력
-                                parameterWithName("cursor").description("마지막으로 조회한 경험기록 id(최초 조회 시 null)"),
+                                parameterWithName("cursor").description("마지막으로 조회한 경험기록 id. 최초 조회시에는 이 파라미터를 포함하지 않고, 두 번째 요청부터 포함해야 합니다."),
                                 parameterWithName("limit").description("한번에 조회해올 데이터 갯수")
                         ),
                         responseFields(


### PR DESCRIPTION
## 개요
- 키워드 기반 경험 조회 시, 조회된 경험이 없을 경우, 응답 response 에 curosr 값 임의로 추가

## 작업사항
- 조회된 경험이 없을 경우, 응답 response cursor 필드에 0으로 셋팅

## 변경로직
cursor 값
- as-is: npe 발생
- to-be: 0

## 논의하고 싶은 부분
응답 response에 cursor가 0이면, `더 이상 조회할 데이터가 없음`을 의미하는 것으로 할까요?
-> 0 or cursor필드 내려주지 않음 or null로 내려줌 등등 다양한 방식이 있을 것 같은데 한가지 방식으로 정하고 api문서 설명에도 보강하면 좋을 것 같습니다!