### PR TITLE
경험저장 api 응답 response body에 새로추가된 recordId 추가

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -137,6 +137,7 @@ include::{snippets}/record/save-record/request-part-recordInfo-fields.adoc[]
 ==== Response
 include::{snippets}/record/save-record/http-response.adoc[]
 include::{snippets}/record/save-record/response-headers.adoc[]
+include::{snippets}/record/save-record/response-fields.adoc[]
 
 === 특정 사용자의 전통주 경험 조회
 ==== Request

--- a/backend/src/main/java/sullog/backend/record/controller/RecordController.java
+++ b/backend/src/main/java/sullog/backend/record/controller/RecordController.java
@@ -39,7 +39,7 @@ public class RecordController {
     }
 
     @PostMapping
-    public ResponseEntity<URI> saveRecord(@RequestAttribute Integer memberId,
+    public ResponseEntity<RecordSaveDto> saveRecord(@RequestAttribute Integer memberId,
                                              @RequestPart(required = false) List<MultipartFile> photoList,
                                              @RequestPart("recordInfo") RecordSaveRequestDto requestDto) {
         // 이미지 저장
@@ -53,7 +53,12 @@ public class RecordController {
                 .path("/{recordId}")
                 .buildAndExpand(savedRecordId)
                 .toUri();
-        return ResponseEntity.created(location).build();
+
+        RecordSaveDto responseBody = RecordSaveDto.builder()
+                .recordId(savedRecordId)
+                .build();
+
+        return ResponseEntity.created(location).body(responseBody);
     }
 
     @GetMapping("/me")

--- a/backend/src/main/java/sullog/backend/record/dto/response/RecordSaveDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/RecordSaveDto.java
@@ -1,0 +1,13 @@
+package sullog.backend.record.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public class RecordSaveDto {
+
+    private Integer recordId; // 경험기록 id
+
+    public Integer getRecordId() {
+        return recordId;
+    }
+}

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -152,8 +152,11 @@ class RecordControllerTest {
                         )),
                         responseHeaders(
                                 headerWithName(HttpHeaders.LOCATION).description("방금 저장된 경험기록에 접근할 수 있는 url")
+                        ),
+                        responseFields(
+                                fieldWithPath("recordId").type(JsonFieldType.NUMBER).description("방금 저장된 경험기록 id"))
                         )
-                ));
+                );
     }
 
     @Test


### PR DESCRIPTION
## 개요
- #98 이슈 후속 대응 (디스코드에서 location에 uri 담는 방식 말고 recordId만 전달 요청주심)

## 작업사항
응답 response body에 recordId 전달되도록 수정
```
{
    "recordId": 44
}
```

## 변경로직
경험저장 api 응답 response
- as-is: N/A
- to-be: 방금 저장된 경험기록 id

