### PR TITLE
경험 저장 시 이미지 확장자 제한 확대

### DIFF
--- a/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
+++ b/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
 
     // Record
     IMAGE_STORAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "R001", "Fail to Upload Image"),
-    IMAGE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "R002", "Invalid Image Format. jpeg, png Only Allowed")
+    IMAGE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "R002", "Invalid Image Format")
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/sullog/backend/record/service/ImageUploadServiceAwsImpl.java
+++ b/backend/src/main/java/sullog/backend/record/service/ImageUploadServiceAwsImpl.java
@@ -36,6 +36,9 @@ public class ImageUploadServiceAwsImpl implements ImageUploadService{
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    @Value("#{'${allow-image-format}'.split(',')}")
+    private List<String> allowedExtensions;
+
     @PostConstruct
     public void setS3Client() {
         AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
@@ -88,14 +91,10 @@ public class ImageUploadServiceAwsImpl implements ImageUploadService{
 
     private String getFileContentType(String fileName) {
         String ext = fileName.substring(fileName.lastIndexOf(".") + 1);
-
-        switch (ext) {
-            case "jpeg":
-                return "image/jpeg";
-            case "png":
-                return "image/png";
-            default:
-                throw new RecordException(ErrorCode.IMAGE_FORMAT_ERROR);
+        if (false == allowedExtensions.contains(ext)) {
+            throw new RecordException(ErrorCode.IMAGE_FORMAT_ERROR);
         }
+
+        return "image/"+ext;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,3 +16,5 @@ spring:
 server:
   port: 8081
 
+# 허용하는 이미지 확장자
+allow-image-format: "jpg,JPG,jpeg,JPEG,png,PNG,heic,HEIC"

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -141,7 +141,7 @@ class RecordControllerTest {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestParts(List.of(
-                                partWithName("photoList").description("사용자가 업로드한 이미지 리스트(0 ~ 3장)").optional(),
+                                partWithName("photoList").description("사용자가 업로드한 이미지 리스트(0 ~ 3장) jpg,jpeg,png,heic 확장자만 허용").optional(),
                                 partWithName("recordInfo").description("사용자가 작성한 전통주 경험")
                         )),
                         requestPartFields("recordInfo", List.of(

--- a/backend/src/test/java/sullog/backend/record/service/ImageUploadServiceAwsImplTest.java
+++ b/backend/src/test/java/sullog/backend/record/service/ImageUploadServiceAwsImplTest.java
@@ -1,0 +1,44 @@
+package sullog.backend.record.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import sullog.backend.record.error.exception.RecordException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ImageUploadServiceAwsImplTest {
+
+    @InjectMocks
+    private ImageUploadServiceAwsImpl imageUploadService;
+
+    private List<String> allowedExtensions = List.of("jpg", "JPG", "jpeg", "JPEG", "png", "PNG", "heic", "HEIC");
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        ReflectionTestUtils.setField(imageUploadService, "allowedExtensions", allowedExtensions);
+    }
+
+    @Test
+    void 허용된_이미지포맷이_아니면_예외가_발생한다() {
+        MultipartFile invalidFormatImage = createTestFile("test1", "invalid");
+        assertThrows(RecordException.class, () -> {
+            imageUploadService.uploadImageList(List.of(invalidFormatImage));
+        });
+    }
+
+    MultipartFile createTestFile(String originalFileName, String contentType) {
+        return new MockMultipartFile("test", originalFileName+"."+contentType, contentType, "test".getBytes());
+    }
+
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -26,3 +26,5 @@ cloud:
       static: us-east-2
     stack:
       auto: false
+# 허용하는 이미지 확장자
+allow-image-format: "jpg,JPG,jpeg,JPEG,png,PNG,heic,HEIC"


### PR DESCRIPTION
## 개요
- #126 기존에 너무 빡빡하게 하고 있어서, 흔히 쓰이는 확장자들은 허용하도록 수정

## 작업사항
허용하는 확장자 확대
- 확장자는 application.yml 을 통해, 외부설정파일로 관리

## 변경로직
- as-is: jpeg, png
- to-be: jpg,jpeg,png,heic

## 참고
단위테스트작성시 @Value를 이용하는게 어려워서, test code에서는 주입받지 않고 박아둠