### PR TITLE
fix: 경험 관련 조회 리턴 필드 수정 및 카카오 redirect-uri 수정 요청 반영

### DIFF
--- a/backend/src/main/java/sullog/backend/record/dto/response/AllRecordMeta.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/AllRecordMeta.java
@@ -14,7 +14,7 @@ public class AllRecordMeta {
     private String productionLocation; // 생산지 명
     private Double productionLatitude; // 전통주 생산지 위도
     private Double productionLongitude; // 전통주 생산지 경도
-    private String alcoholTag; // 전통주 태그
+    private String alcoholType; // 주종
     private String brandName; // 브랜드 이름
 
     public Integer getMemberId() {
@@ -53,8 +53,8 @@ public class AllRecordMeta {
         return productionLongitude;
     }
 
-    public String getAlcoholTag() {
-        return alcoholTag;
+    public String getAlcoholType() {
+        return alcoholType;
     }
 
     public String getBrandName() {

--- a/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/response/RecordMetaDto.java
@@ -13,7 +13,7 @@ public class RecordMetaDto {
     private String productionLocation; // 생산지 명
     private double productionLatitude; // 전통주 생산지 위도
     private double productionLongitude; // 전통주 생산지 경도
-    private String alcoholTag; // 전통주 태그
+    private String alcoholType; // 주종
     private String brandName; // 브랜드 이름
 
     public int getRecordId() {
@@ -48,8 +48,8 @@ public class RecordMetaDto {
         return productionLongitude;
     }
 
-    public String getAlcoholTag() {
-        return alcoholTag;
+    public String getAlcoholType() {
+        return alcoholType;
     }
 
     public String getBrandName() {

--- a/backend/src/main/java/sullog/backend/record/dto/table/AllRecordMetaWithAlcoholInfoDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/table/AllRecordMetaWithAlcoholInfoDto.java
@@ -19,7 +19,7 @@ public class AllRecordMetaWithAlcoholInfoDto {
     private String productionLocation;
     private Double productionLatitude;
     private Double productionLongitude;
-    private String alcoholTag;
+    private String alcoholType;
     private String brandName;
 
     public Integer getMemberId() {
@@ -62,8 +62,8 @@ public class AllRecordMetaWithAlcoholInfoDto {
         return productionLongitude;
     }
 
-    public String getAlcoholTag() {
-        return alcoholTag;
+    public String getAlcoholType() {
+        return alcoholType;
     }
 
     public AllRecordMetaWithAlcoholInfoDto(
@@ -76,7 +76,7 @@ public class AllRecordMetaWithAlcoholInfoDto {
             String productionLocation,
             Double productionLatitude,
             Double productionLongitude,
-            String alcoholTag,
+            String alcoholType,
             String brandName) {
         this.memberId = memberId;
         this.recordId = recordId;
@@ -87,7 +87,7 @@ public class AllRecordMetaWithAlcoholInfoDto {
         this.productionLocation = productionLocation;
         this.productionLatitude = productionLatitude;
         this.productionLongitude = productionLongitude;
-        this.alcoholTag = alcoholTag;
+        this.alcoholType = alcoholType;
         this.brandName = brandName;
     }
 
@@ -102,7 +102,7 @@ public class AllRecordMetaWithAlcoholInfoDto {
                 .productionLocation(productionLocation)
                 .productionLatitude(productionLatitude)
                 .productionLongitude(productionLongitude)
-                .alcoholTag(alcoholTag)
+                .alcoholType(alcoholType)
                 .brandName(brandName)
                 .build();
     }

--- a/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
+++ b/backend/src/main/java/sullog/backend/record/dto/table/RecordMetaWithAlcoholInfoDto.java
@@ -16,7 +16,7 @@ public class RecordMetaWithAlcoholInfoDto {
     private String productionLocation;
     private double productionLatitude;
     private double productionLongitude;
-    private String alcoholTag;
+    private String alcoholType;
     private String brandName;
 
     public int getRecordId() {
@@ -51,8 +51,8 @@ public class RecordMetaWithAlcoholInfoDto {
         return productionLongitude;
     }
 
-    public String getAlcoholTag() {
-        return alcoholTag;
+    public String getAlcoholType() {
+        return alcoholType;
     }
 
     public RecordMetaDto toResponseDto() {
@@ -65,7 +65,7 @@ public class RecordMetaWithAlcoholInfoDto {
                 .productionLocation(productionLocation)
                 .productionLatitude(productionLatitude)
                 .productionLongitude(productionLongitude)
-                .alcoholTag(alcoholTag)
+                .alcoholType(alcoholType)
                 .brandName(brandName)
                 .build();
     }

--- a/backend/src/main/resources/mapper/record/RecordMapper.xml
+++ b/backend/src/main/resources/mapper/record/RecordMapper.xml
@@ -43,7 +43,7 @@
         <result property="productionLocation" column="production_location"/>
         <result property="productionLatitude" column="production_latitude"/>
         <result property="productionLongitude" column="production_longitude"/>
-        <result property="alcoholTag" column="alcohol_tag"/>
+        <result property="alcoholType" column="alcohol_type"/>
         <result property="brandName" column="brand_name"/>
     </resultMap>
 
@@ -56,7 +56,7 @@
                a.production_location  AS production_location,
                a.production_latitude  AS production_latitude,
                a.production_longitude AS production_longitude,
-               a.alcohol_tag          AS alcohol_tag,
+               a.alcohol_type         AS alcohol_type,
                ab.name                AS brand_name
         FROM record AS r
         LEFT JOIN (SELECT alcohol_id,
@@ -65,7 +65,7 @@
                           production_location,
                           production_latitude,
                           production_longitude,
-                          alcohol_tag
+                          alcohol_type
                     FROM alcohol) AS a
             ON r.alcohol_id = a.alcohol_id
         LEFT JOIN alcohol_brand AS ab
@@ -114,7 +114,7 @@
                 a.production_location  AS production_location,
                 a.production_latitude  AS production_latitude,
                 a.production_longitude AS production_longitude,
-                a.alcohol_tag          AS alcohol_tag,
+                a.alcohol_type         AS alcohol_type,
                 ab.name                AS brand_name
         FROM record AS r
         LEFT JOIN (SELECT   alcohol_id,
@@ -123,7 +123,7 @@
                             production_location,
                             production_latitude,
                             production_longitude,
-                            alcohol_tag
+                            alcohol_type
                             FROM alcohol) AS a
             ON r.alcohol_id = a.alcohol_id
         LEFT JOIN alcohol_brand AS ab
@@ -155,7 +155,7 @@
         <result property="productionLocation" column="production_location"/>
         <result property="productionLatitude" column="production_latitude"/>
         <result property="productionLongitude" column="production_longitude"/>
-        <result property="alcoholTag" column="alcohol_tag"/>
+        <result property="alcoholType" column="alcohol_type"/>
         <result property="brandName" column="brand_name"/>
     </resultMap>
 
@@ -170,7 +170,7 @@
         a.production_location  AS production_location,
         a.production_latitude  AS production_latitude,
         a.production_longitude AS production_longitude,
-        a.alcohol_tag          AS alcohol_tag,
+        a.alcohol_type         AS alcohol_type,
         ab.name                AS brand_name
         FROM record AS r
         LEFT JOIN (
@@ -180,7 +180,7 @@
                     production_location,
                     production_latitude,
                     production_longitude,
-                    alcohol_tag
+                    alcohol_type
             FROM alcohol
         ) AS a
         ON r.alcohol_id = a.alcohol_id

--- a/backend/src/main/resources/oauth-alpha.yml
+++ b/backend/src/main/resources/oauth-alpha.yml
@@ -5,7 +5,7 @@ spring:
         registration:
           kakao:
             client-id: 209bdcaaebd1d90d002f358651d8ef4b
-            redirect-uri: http://localhost:3000/login
+            redirect-uri: http://localhost:3000/api/redirect/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: POST
             client-name: Kakao

--- a/backend/src/main/resources/oauth-local.yml
+++ b/backend/src/main/resources/oauth-local.yml
@@ -5,7 +5,7 @@ spring:
         registration:
           kakao:
             client-id: 209bdcaaebd1d90d002f358651d8ef4b
-            redirect-uri: http://localhost:3000/login
+            redirect-uri: http://localhost:3000/api/redirect/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: POST
             client-name: Kakao

--- a/backend/src/main/resources/static/docs/api-doc.html
+++ b/backend/src/main/resources/static/docs/api-doc.html
@@ -1056,7 +1056,7 @@ test2
 Content-Disposition: form-data; name=recordInfo
 Content-Type: application/json
 
-{"alcoholId":1,"alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"starScore":5,"scentScore":3,"tasteScore":4,"textureScore":5,"description":"This is a test record.","experienceDate":"2023-05-22"}
+{"alcoholId":1,"alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"starScore":5,"scentScore":3,"tasteScore":4,"textureScore":5,"description":"This is a test record.","experienceDate":"2023-06-18"}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -1074,7 +1074,7 @@ Content-Type: application/json
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>photoList</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자가 업로드한 이미지 리스트(0 ~ 3장)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자가 업로드한 이미지 리스트(0 ~ 3장) jpg,jpeg,png,heic 확장자만 허용</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>recordInfo</code></p></td>
@@ -1227,7 +1227,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 1061
+Content-Length: 1062
 
 [ {
   "recordId" : 1,
@@ -1238,7 +1238,7 @@ Content-Length: 1061
   "productionLocation" : "서울시 광진구 능동로 120",
   "productionLatitude" : 37.123456,
   "productionLongitude" : 126.789012,
-  "alcoholTag" : "SOJU",
+  "alcoholType" : "소주",
   "brandName" : "진로"
 }, {
   "recordId" : 2,
@@ -1249,7 +1249,7 @@ Content-Length: 1061
   "productionLocation" : "서울시 광진구 능동로 120",
   "productionLatitude" : 36.987654,
   "productionLongitude" : 127.012345,
-  "alcoholTag" : "FRUIT_WINE",
+  "alcoholType" : "와인",
   "brandName" : "진로"
 }, {
   "recordId" : 3,
@@ -1260,7 +1260,7 @@ Content-Length: 1061
   "productionLocation" : "서울시 광진구 능동로 120",
   "productionLatitude" : 35.123456,
   "productionLongitude" : 128.789012,
-  "alcoholTag" : "MAKGEOLLI",
+  "alcoholType" : "막걸리",
   "brandName" : "진로"
 } ]</code></pre>
 </div>
@@ -1320,9 +1320,9 @@ Content-Length: 1061
 <td class="tableblock halign-left valign-top"><p class="tableblock">전통주 생산지 경도</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].alcoholTag</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].alcoholType</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">전통주 태그</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주종</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].brandName</code></p></td>
@@ -1396,12 +1396,12 @@ Content-Length: 841
     "alcoholId" : 1,
     "alcoholName" : "전통주 샘플",
     "brandName" : "진로",
-    "alcoholType" : null,
+    "alcoholType" : "약주",
     "alcoholPercent" : 10.0,
     "productionLocation" : "서울시 광진구",
     "productionLatitude" : 127.077794504202,
     "productionLongitude" : 37.54373496690244,
-    "alcoholTag" : "SOJU"
+    "alcoholTag" : ""
   }
 }</code></pre>
 </div>
@@ -1517,7 +1517,7 @@ Content-Length: 841
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>alcoholInfo.alcoholType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">주종</p></td>
 </tr>
 <tr>
@@ -1605,7 +1605,7 @@ Content-Length: 834
     "productionLocation" : "서울시 광진구 능동로 120",
     "productionLatitude" : 37.123456,
     "productionLongitude" : 126.789012,
-    "alcoholTag" : "SOJU",
+    "alcoholType" : "소주",
     "brandName" : "진로"
   }, {
     "recordId" : 2,
@@ -1616,7 +1616,7 @@ Content-Length: 834
     "productionLocation" : "서울시 광진구 능동로 120",
     "productionLatitude" : 36.987654,
     "productionLongitude" : 127.012345,
-    "alcoholTag" : "FRUIT_WINE",
+    "alcoholType" : "와인",
     "brandName" : "진로"
   } ],
   "pagingInfo" : {
@@ -1686,9 +1686,9 @@ Content-Length: 834
 <td class="tableblock halign-left valign-top"><p class="tableblock">전통주 생산지 경도</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recordMetaList[].alcoholTag</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recordMetaList[].alcoholType</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">전통주 태그</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주종</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>recordMetaList[].brandName</code></p></td>
@@ -1754,7 +1754,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 877
+Content-Length: 880
 
 {
   "allRecordMetaList" : [ {
@@ -1767,7 +1767,7 @@ Content-Length: 877
     "productionLocation" : "서울시 광진구 능동로 120",
     "productionLatitude" : 37.123456,
     "productionLongitude" : 126.789012,
-    "alcoholTag" : "SOJU",
+    "alcoholType" : "소주",
     "brandName" : "진로"
   }, {
     "memberId" : 2,
@@ -1779,7 +1779,7 @@ Content-Length: 877
     "productionLocation" : "서울시 광진구 능동로 120",
     "productionLatitude" : 36.987654,
     "productionLongitude" : 127.012345,
-    "alcoholTag" : "FRUIT_WINE",
+    "alcoholType" : "막걸리",
     "brandName" : "진로"
   } ],
   "pagingInfo" : {
@@ -1854,9 +1854,9 @@ Content-Length: 877
 <td class="tableblock halign-left valign-top"><p class="tableblock">전통주 생산지 경도</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>allRecordMetaList[].alcoholTag</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>allRecordMetaList[].alcoholType</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">전통주 태그</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">주종</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>allRecordMetaList[].brandName</code></p></td>
@@ -2261,7 +2261,7 @@ Content-Length: 172
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-05-22 00:08:07 +0900
+Last updated 2023-06-06 20:01:19 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
+++ b/backend/src/test/java/sullog/backend/record/controller/RecordControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import sullog.backend.alcohol.dto.response.AlcoholInfoDto;
 import sullog.backend.alcohol.service.AlcoholService;
-import sullog.backend.common.config.WebMvcConfig;
 import sullog.backend.member.config.jwt.JwtAuthFilter;
 import sullog.backend.auth.service.TokenService;
 import sullog.backend.member.entity.Member;
@@ -194,7 +193,7 @@ class RecordControllerTest {
                 .andExpect(jsonPath("$[0].productionLocation", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLocation())))
                 .andExpect(jsonPath("$[0].productionLatitude", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLatitude())))
                 .andExpect(jsonPath("$[0].productionLongitude", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getProductionLongitude())))
-                .andExpect(jsonPath("$[0].alcoholTag", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getAlcoholTag())))
+                .andExpect(jsonPath("$[0].alcoholType", is(recordMetaWithAlcoholInfoDtos.get(0).toResponseDto().getAlcoholType())))
                 .andDo(document("record/get-records-by-memberId",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
@@ -207,7 +206,7 @@ class RecordControllerTest {
                                 fieldWithPath("[].productionLocation").description("전통주 생산지 명"),
                                 fieldWithPath("[].productionLatitude").description("전통주 생산지 위도"),
                                 fieldWithPath("[].productionLongitude").description("전통주 생산지 경도"),
-                                fieldWithPath("[].alcoholTag").description("전통주 태그"),
+                                fieldWithPath("[].alcoholType").description("주종"),
                                 fieldWithPath("[].brandName").description("브랜드 이름")
                         ))
                 );
@@ -223,7 +222,7 @@ class RecordControllerTest {
                 .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(37.123456)
                 .productionLongitude(126.789012)
-                .alcoholTag("SOJU")
+                .alcoholType("소주")
                 .brandName("진로")
                 .build();
 
@@ -236,7 +235,7 @@ class RecordControllerTest {
                 .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(36.987654)
                 .productionLongitude(127.012345)
-                .alcoholTag("FRUIT_WINE")
+                .alcoholType("와인")
                 .brandName("진로")
                 .build();
 
@@ -249,7 +248,7 @@ class RecordControllerTest {
                 .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(35.123456)
                 .productionLongitude(128.789012)
-                .alcoholTag("MAKGEOLLI")
+                .alcoholType("막걸리")
                 .brandName("진로")
                 .build();
 
@@ -331,7 +330,8 @@ class RecordControllerTest {
         return AlcoholInfoDto.builder()
                 .alcoholId(1)
                 .alcoholName("전통주 샘플")
-                .alcoholTag("SOJU")
+                .alcoholTag("")
+                .alcoholType("약주")
                 .alcoholPercent(10.0)
                 .productionLocation("서울시 광진구")
                 .productionLongitude(37.54373496690244)
@@ -386,7 +386,7 @@ class RecordControllerTest {
                                 fieldWithPath("recordMetaList[].productionLocation").description("전통주 생산지 명"),
                                 fieldWithPath("recordMetaList[].productionLatitude").description("전통주 생산지 위도"),
                                 fieldWithPath("recordMetaList[].productionLongitude").description("전통주 생산지 경도"),
-                                fieldWithPath("recordMetaList[].alcoholTag").description("전통주 태그"),
+                                fieldWithPath("recordMetaList[].alcoholType").description("주종"),
                                 fieldWithPath("recordMetaList[].brandName").description("브랜드 이름"),
                                 fieldWithPath("pagingInfo").type(JsonFieldType.OBJECT).description("페이징 정보"),
                                 fieldWithPath("pagingInfo.cursor").type(JsonFieldType.NUMBER).description("마지막으로 조회한 경험기록 id(다음요청 시 그대로 전달)"),
@@ -439,7 +439,7 @@ class RecordControllerTest {
                                 fieldWithPath("allRecordMetaList[].productionLocation").description("전통주 생산지 명"),
                                 fieldWithPath("allRecordMetaList[].productionLatitude").description("전통주 생산지 위도"),
                                 fieldWithPath("allRecordMetaList[].productionLongitude").description("전통주 생산지 경도"),
-                                fieldWithPath("allRecordMetaList[].alcoholTag").description("전통주 태그"),
+                                fieldWithPath("allRecordMetaList[].alcoholType").description("주종"),
                                 fieldWithPath("allRecordMetaList[].brandName").description("브랜드 이름"),
                                 fieldWithPath("pagingInfo").type(JsonFieldType.OBJECT).description("페이징 정보"),
                                 fieldWithPath("pagingInfo.cursor").type(JsonFieldType.NUMBER).description("마지막으로 조회한 경험기록 id(다음요청 시 그대로 전달)"),
@@ -501,7 +501,7 @@ class RecordControllerTest {
                 .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(37.123456)
                 .productionLongitude(126.789012)
-                .alcoholTag("SOJU")
+                .alcoholType("소주")
                 .brandName("진로")
                 .build();
 
@@ -515,7 +515,7 @@ class RecordControllerTest {
                 .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(36.987654)
                 .productionLongitude(127.012345)
-                .alcoholTag("FRUIT_WINE")
+                .alcoholType("막걸리")
                 .brandName("진로")
                 .build();
 
@@ -529,7 +529,7 @@ class RecordControllerTest {
                 .productionLocation("서울시 광진구 능동로 120")
                 .productionLatitude(35.123456)
                 .productionLongitude(128.789012)
-                .alcoholTag("MAKGEOLLI")
+                .alcoholType("와인")
                 .brandName("진로")
                 .build();
 


### PR DESCRIPTION
## 개요
- 경험 관련 조회 리턴 필드 수정 및 카카오 redirect-uri 수정 요청 반영

## 작업사항
- 경험 관련 조회 리턴 필드 수정
    - 경험 조회 시 주종 필드가 없고, 대신 미사용 중인 alcoholTag 필드가 리턴되어서 alcoholTag필드 자체를 지우고, 주종(alcoholType)을 리턴하도록 함
- 프론트측 카카오 redirect-uri 수정 요청 반영

## 변경로직
- redirect-uri 수정
    - as-is: http://localhost:3000/login
    - to-be: http://localhost:3000/api/redirect/kakao 
