### PR TITLE
deploy: 운영서버(live), 개발서버(alpha) 분리를 위한 설정 변경

### DIFF
--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -51,10 +51,10 @@
 |===
 | 환경 | domain
 
-| 개발서버
-| `http://ec2-13-124-179-45.ap-northeast-2.compute.amazonaws.com:8081`
+| 개발서버 (alpha)
+| `http://ec2-13-124-179-45.ap-northeast-2.compute.amazonaws.com:8082`
 
-| Prod / 운영 서버
+| 운영서버 (live)
 | `https://api.sullog-server.click`
 |===
 

--- a/backend/src/main/resources/application-alpha.yml
+++ b/backend/src/main/resources/application-alpha.yml
@@ -1,6 +1,6 @@
 spring:
   pid:
-    file: /home/ubuntu/deploy/sullog.pid
+    file: /home/ubuntu/alpha/sullog.pid
   config:
     import: "classpath:oauth-alpha.yml"
   datasource:
@@ -29,5 +29,4 @@ logging:
   config: classpath:log4j2-alpha.yml
 
 # CORS 이슈 대응
-client-domains: "https://sullog-client.vercel.app,https://sullog-dev.vercel.app"
-#client-domains: "http://localhost:3000"
+client-domains: "http://localhost:3000"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       - jwt
       - aws
       - mybatis
-    active: alpha   # local, alpha, live
+    active: live   # local, alpha, live
 server:
   port: 8081
 

--- a/backend/src/main/resources/log4j2-alpha.yml
+++ b/backend/src/main/resources/log4j2-alpha.yml
@@ -5,7 +5,7 @@ Configuration:
   Properties:
     Property:
       name: log-path
-      value: "/home/ubuntu/deploy/logs"
+      value: "/home/ubuntu/alpha/logs"
 
   Appenders:
     RollingFile:

--- a/backend/src/main/resources/oauth-alpha.yml
+++ b/backend/src/main/resources/oauth-alpha.yml
@@ -5,8 +5,7 @@ spring:
         registration:
           kakao:
             client-id: 209bdcaaebd1d90d002f358651d8ef4b
-#            redirect-uri: http://localhost:3000/api/redirect/kakao
-            redirect-uri: https://sullog-client.vercel.app/api/redirect/kakao
+            redirect-uri: http://localhost:3000/api/redirect/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: POST
             client-name: Kakao

--- a/backend/src/main/resources/oauth-live.yml
+++ b/backend/src/main/resources/oauth-live.yml
@@ -5,7 +5,7 @@ spring:
         registration:
           kakao:
             client-id: 209bdcaaebd1d90d002f358651d8ef4b
-            redirect-uri: https://sullog-client.vercel.app/login
+            redirect-uri: https://sullog-client.vercel.app/api/redirect/kakao
             authorization-grant-type: authorization_code
             client-authentication-method: POST
             client-name: Kakao


### PR DESCRIPTION
## 개요
- 프론트 요청으로 서버를 2개로 운영
- 운영서버(live), 개발서버(alpha) 분리를 위한 설정 변경

## 작업사항
- 프론트의 로컬 서버 == 백엔드의 alpha 서버
- 프론트의 alpha, live 서버 == 백엔드의 live 서버

## 참고
- alpha 서버의 경우 8082포트 사용하도록 변경
