### PR TITLE
애플 로그인 기능 추가 - 회원가입 후 로그인 케이스

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    // https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15to18
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk15to18', version: '1.75'
+    // https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15to18
+    implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15to18', version: '1.71'
 
     //oauth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -51,6 +55,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
 
     // S3 upload
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -70,12 +70,23 @@ include::{snippets}/oauth2/request-kakao-login/request-parameters.adoc[]
 include::{snippets}/token-refresh/http-response.adoc[]
 include::{snippets}/token-refresh/response-headers.adoc[]
 
-=== 애플 로그인 요청
+=== 애플 로그인 요청(최초 가입)
 클라이언트에서 인가코드와 유저 정보를 넘겨주면, 인가코드 기반으로 유저정보를 검증하고 jwt토큰 반환
 
 ==== Request
-include::{snippets}/oauth2/request-apple-login/http-request.adoc[]
-include::{snippets}/oauth2/request-apple-login/request-fields.adoc[]
+include::{snippets}/oauth2/request-apple-login-register/http-request.adoc[]
+include::{snippets}/oauth2/request-apple-login-register/request-fields.adoc[]
+
+==== Response
+include::{snippets}/token-refresh/http-response.adoc[]
+include::{snippets}/token-refresh/response-headers.adoc[]
+
+=== 애플 로그인 요청(로그인 풀려서 로그인)
+클라이언트에서 인가코드를 넘겨주면, 인가코드 기반으로 유저정보를 조회해서 jwt토큰 반환
+
+==== Request
+include::{snippets}/oauth2/request-apple-login-after-register/http-request.adoc[]
+include::{snippets}/oauth2/request-apple-login-after-register/request-fields.adoc[]
 
 ==== Response
 include::{snippets}/token-refresh/http-response.adoc[]

--- a/backend/src/docs/asciidoc/api-doc.adoc
+++ b/backend/src/docs/asciidoc/api-doc.adoc
@@ -70,6 +70,17 @@ include::{snippets}/oauth2/request-kakao-login/request-parameters.adoc[]
 include::{snippets}/token-refresh/http-response.adoc[]
 include::{snippets}/token-refresh/response-headers.adoc[]
 
+=== 애플 로그인 요청
+클라이언트에서 인가코드와 유저 정보를 넘겨주면, 인가코드 기반으로 유저정보를 검증하고 jwt토큰 반환
+
+==== Request
+include::{snippets}/oauth2/request-apple-login/http-request.adoc[]
+include::{snippets}/oauth2/request-apple-login/request-fields.adoc[]
+
+==== Response
+include::{snippets}/token-refresh/http-response.adoc[]
+include::{snippets}/token-refresh/response-headers.adoc[]
+
 === jwt 토큰 리프레시
 
 ==== Request

--- a/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
@@ -3,10 +3,9 @@ package sullog.backend.auth.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import sullog.backend.auth.dto.request.AppleLoginRequestDto;
+import sullog.backend.auth.service.AppleService;
 import sullog.backend.auth.service.KakaoService;
 import sullog.backend.member.entity.Member;
 import sullog.backend.member.entity.Token;
@@ -18,11 +17,13 @@ public class AuthController {
 
     private final TokenService tokenService;
     private final KakaoService kakaoService;
+    private final AppleService appleService;
     private final MemberService memberService;
 
-    public AuthController(TokenService tokenService, KakaoService kakaoService, MemberService memberService) {
+    public AuthController(TokenService tokenService, KakaoService kakaoService, AppleService appleService, MemberService memberService) {
         this.tokenService = tokenService;
         this.kakaoService = kakaoService;
+        this.appleService = appleService;
         this.memberService = memberService;
     }
 
@@ -66,4 +67,30 @@ public class AuthController {
                 .headers(headers)
                 .build();
     }
+
+    @PostMapping("/apple")
+    public ResponseEntity<Void> appleLogin(@RequestBody AppleLoginRequestDto appleLoginRequestDto) throws JsonProcessingException {
+        // 인가코드로 user정보 검증
+        Member needVerifyMember = appleLoginRequestDto.authorizedMember();
+        Member verifiedMember = appleService.verifyUserInfo(appleLoginRequestDto.getCode(), needVerifyMember);
+
+        // 회원가입 절차 진행
+        memberService.registerMember(verifiedMember);
+
+        // 회원정보 조회
+        Member findMember = memberService.findMemberByEmail(verifiedMember.getEmail());
+
+        // 토큰 발급
+        Token token = tokenService.generateToken(findMember.getMemberId(), "USER");
+
+        // response 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, token.getAccessToken());
+        headers.set("Refresh", token.getRefreshToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .build();
+    }
+
 }

--- a/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/sullog/backend/auth/controller/AuthController.java
@@ -72,7 +72,15 @@ public class AuthController {
     public ResponseEntity<Void> appleLogin(@RequestBody AppleLoginRequestDto appleLoginRequestDto) throws JsonProcessingException {
         // 인가코드로 user정보 검증
         Member needVerifyMember = appleLoginRequestDto.authorizedMember();
-        Member verifiedMember = appleService.verifyUserInfo(appleLoginRequestDto.getCode(), needVerifyMember);
+        Member verifiedMember;
+
+        if (null == needVerifyMember) {
+            // 로그인 2회차 이상 케이스
+            verifiedMember = appleService.getAppleUserInfo(appleLoginRequestDto.getCode());
+        } else {
+            // 최초 로그인 케이스
+            verifiedMember = appleService.verifyUserInfo(appleLoginRequestDto.getCode(), needVerifyMember);
+        }
 
         // 회원가입 절차 진행
         memberService.registerMember(verifiedMember);

--- a/backend/src/main/java/sullog/backend/auth/dto/request/AppleLoginRequestDto.java
+++ b/backend/src/main/java/sullog/backend/auth/dto/request/AppleLoginRequestDto.java
@@ -1,9 +1,12 @@
 package sullog.backend.auth.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import org.springframework.util.StringUtils;
 import sullog.backend.member.entity.Member;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
 @AllArgsConstructor
 public class AppleLoginRequestDto {
@@ -28,6 +31,14 @@ public class AppleLoginRequestDto {
     }
 
     public Member authorizedMember(){
+        if (false == StringUtils.hasText(email)) {
+            return null;
+        }
+
+        if (false == StringUtils.hasText(name)) {
+            return null;
+        }
+
         return Member.ofRegisterMember(email, name);
     }
 

--- a/backend/src/main/java/sullog/backend/auth/dto/request/AppleLoginRequestDto.java
+++ b/backend/src/main/java/sullog/backend/auth/dto/request/AppleLoginRequestDto.java
@@ -1,0 +1,34 @@
+package sullog.backend.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import sullog.backend.member.entity.Member;
+
+@Builder
+@AllArgsConstructor
+public class AppleLoginRequestDto {
+
+    private String code;
+    private String name;
+    private String email;
+
+    public AppleLoginRequestDto() {
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Member authorizedMember(){
+        return Member.ofRegisterMember(email, name);
+    }
+
+}

--- a/backend/src/main/java/sullog/backend/auth/service/AppleService.java
+++ b/backend/src/main/java/sullog/backend/auth/service/AppleService.java
@@ -1,0 +1,151 @@
+package sullog.backend.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.ReadOnlyJWTClaimsSet;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import sullog.backend.common.error.ErrorCode;
+import sullog.backend.common.error.exception.BusinessException;
+import sullog.backend.member.entity.Member;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.PrivateKey;
+import java.text.ParseException;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Service
+public class AppleService {
+
+    private final OAuth2ClientProperties oAuth2ClientProperties;
+    private final ObjectMapper objectMapper;
+    private final String keyId;
+    private final String teamId;
+    private final String privateKeyPath;
+
+
+    public AppleService(OAuth2ClientProperties oAuth2ClientProperties,
+                        ObjectMapper objectMapper,
+                        @Value("${apple.key-id}") String keyId,
+                        @Value("${apple.team-id}") String teamId,
+                        @Value("${apple.key-path}") String privateKeyPath) {
+        this.oAuth2ClientProperties = oAuth2ClientProperties;
+        this.objectMapper = objectMapper;
+        this.keyId = keyId;
+        this.teamId = teamId;
+        this.privateKeyPath = privateKeyPath;
+    }
+
+    //https://d0lim.com/blog/2022/06/login-with-apple-workaround/ 에서 code 검증 방식
+    public Member verifyUserInfo(String code, Member needVerifyMember) throws JsonProcessingException {
+        // 애플 oauth2 정보 조회
+        OAuth2ClientProperties.Registration appleRegistration = oAuth2ClientProperties.getRegistration().get("apple");
+        OAuth2ClientProperties.Provider appleProvider = oAuth2ClientProperties.getProvider().get("apple");
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", appleRegistration.getAuthorizationGrantType());
+        body.add("client_id", appleRegistration.getClientId());
+        body.add("redirect_uri", appleRegistration.getRedirectUri());
+        body.add("client_secret", makeClientSecret(appleRegistration.getClientId()));
+        body.add("code", code);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> appleTokenRequest = new HttpEntity<>(body, headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                appleProvider.getTokenUri(),
+                HttpMethod.POST,
+                appleTokenRequest,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        // 예시
+        //{
+        //    "access_token": "....",
+        //    "token_type": "Bearer",
+        //    "expires_in": 3600
+        //    "id_token": "xxxxx"
+        //}
+        JsonNode rootNode = objectMapper.readTree(response.getBody());
+
+        //id_token을 통해 이메일 검증
+        SignedJWT signedJWT;
+        ReadOnlyJWTClaimsSet getPayload;
+        try {
+            signedJWT = SignedJWT.parse(String.valueOf(rootNode.get("id_token").asText()));
+            getPayload = signedJWT.getJWTClaimsSet();
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+
+        JsonNode payload = objectMapper.readTree(getPayload.toJSONObject().toJSONString());
+        String email  = payload.get("email").asText();
+
+        // 애플 로그인 시 redirect uri로 전달받은 user객체 값 검증
+        if (false == needVerifyMember.getEmail().equals(email)) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_VERIFIED);
+        }
+
+        return needVerifyMember;
+    }
+
+    private String makeClientSecret(String clientId) {
+        Date expireDate = Date.from(ZonedDateTime.now().plusMonths(1).toInstant());
+        return Jwts.builder()
+                .setHeaderParam("kid", keyId)
+                .setHeaderParam("alg", "ES256")
+                .setIssuer(teamId)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expireDate)
+                .setAudience("https://appleid.apple.com") // 고정
+                .setSubject(clientId)
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+                .compact();
+    }
+
+    private PrivateKey getPrivateKey() {
+        PrivateKeyInfo object;
+        PrivateKey privateKey;
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+        try {
+            ClassPathResource resource = new ClassPathResource(privateKeyPath);
+            String privateKeyString = new String(Files.readAllBytes(Paths.get(resource.getURI())));
+            Reader pemReader = new StringReader(privateKeyString);
+            PEMParser pemParser = new PEMParser(pemReader);
+            object = (PrivateKeyInfo) pemParser.readObject();
+            privateKey = converter.getPrivateKey(object);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return privateKey;
+    }
+
+}

--- a/backend/src/main/java/sullog/backend/auth/service/AppleService.java
+++ b/backend/src/main/java/sullog/backend/auth/service/AppleService.java
@@ -57,6 +57,11 @@ public class AppleService {
         this.privateKeyPath = privateKeyPath;
     }
 
+    public Member getAppleUserInfo(String code) throws JsonProcessingException {
+        String email = getEmailByCode(code);
+        return Member.ofRegisterMember(email, "");
+    }
+
     //https://d0lim.com/blog/2022/06/login-with-apple-workaround/ 에서 code 검증 방식
     public Member verifyUserInfo(String code, Member needVerifyMember) throws JsonProcessingException {
         String email = getEmailByCode(code);
@@ -118,13 +123,7 @@ public class AppleService {
 
         JsonNode payload = objectMapper.readTree(getPayload.toJSONObject().toJSONString());
         String email  = payload.get("email").asText();
-
-        // 애플 로그인 시 redirect uri로 전달받은 user객체 값 검증
-        if (false == needVerifyMember.getEmail().equals(email)) {
-            throw new BusinessException(ErrorCode.MEMBER_NOT_VERIFIED);
-        }
-
-        return needVerifyMember;
+        return email;
     }
 
     private String makeClientSecret(String clientId) {

--- a/backend/src/main/java/sullog/backend/auth/service/AppleService.java
+++ b/backend/src/main/java/sullog/backend/auth/service/AppleService.java
@@ -59,6 +59,17 @@ public class AppleService {
 
     //https://d0lim.com/blog/2022/06/login-with-apple-workaround/ 에서 code 검증 방식
     public Member verifyUserInfo(String code, Member needVerifyMember) throws JsonProcessingException {
+        String email = getEmailByCode(code);
+
+        // 애플 로그인 시 redirect uri로 전달받은 user객체 값 검증
+        if (false == needVerifyMember.getEmail().equals(email)) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_VERIFIED);
+        }
+
+        return needVerifyMember;
+    }
+
+    private String getEmailByCode(String code) throws JsonProcessingException {
         // 애플 oauth2 정보 조회
         OAuth2ClientProperties.Registration appleRegistration = oAuth2ClientProperties.getRegistration().get("apple");
         OAuth2ClientProperties.Provider appleProvider = oAuth2ClientProperties.getProvider().get("apple");

--- a/backend/src/main/java/sullog/backend/common/config/SecurityConfig.java
+++ b/backend/src/main/java/sullog/backend/common/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                                 "/favicon.ico",
                                 "/docs/api-doc.html", // rest-docs 문서 url
                                 "/kakao", // 카카오 로그인 인가코드 전달받는 path
+                                "/apple", // 애플 로그인 인가코드 전달받는 path
                                 "/" //health-check end point
                     ).permitAll()
                     .anyRequest().authenticated()

--- a/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
+++ b/backend/src/main/java/sullog/backend/common/error/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     MEMBER_UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "M001", "Member Unknown Error"),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M002", "Member Not Found Error"),
     MEMBER_NOT_AUTHORIZED(HttpStatus.UNAUTHORIZED, "M003", "JWT Token Error"),
+    MEMBER_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "M004", "Apple Login Verify Fail"),
 
     // Record
     IMAGE_STORAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "R001", "Fail to Upload Image"),

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -5,7 +5,7 @@ spring:
     driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
     jdbc-url: ENC(I82xieWlXOgnSdf9pob+XXhfPrqYKxsDRghOFNyRNSwogRP2Hw2gXb6AqHNQJR2VAfrSYLrpg9htdh+KUs68REgBNoCt87erFIC1/o8eLISxSs4fdsftalnOhjZ+WJQuz5oBo4IY8X9oWIxHPla8A3+o8WQ/l4wxUo8SQAqPACkbG31ETSs+864CCrd8GY1AWc3Bd3kX0YDIgMaoGf4d1hnSB8q062SEgt2Gvqj9l0GOFB+0lc14rCQEVJOeN80u/HzRqxnmzPo=)
     username: ENC(+s3VvY4FZ+n6yPic4s+FNtXAz9paqMRg)
-    password: ENC(YcswAmAmRikB4To119ar4z9/h/PZwDvZ)
+    password: ENC(itAPUynfS7VMcmz9sU/ihUooqaUz+zlLqmDqj2LZ7+k=)
     hikari: # Connection Pool 설정 (Hikari CP가 해당 역할 수행)
       #        maximum-pool-size: 10
       #        connection-timeout: 5000

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       - jwt
       - aws
       - mybatis
-    active: live   # local, alpha, live
+    active: local   # local, alpha, live
 
 
 # 허용하는 이미지 확장자

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,3 +17,8 @@ spring:
 
 # 허용하는 이미지 확장자
 allow-image-format: "jpg,JPG,jpeg,JPEG,png,PNG,heic,HEIC"
+
+# 애플로그인 관련 공통 정보
+apple:
+  key-id: ENC(ORo6z0J1KSyBrKlYyVJ+yorUTL0w//tE)
+  team-id: ENC(GTa1yuSegpc8cVuJpEGd6evUErK5Szsf)

--- a/backend/src/main/resources/oauth-alpha.yml
+++ b/backend/src/main/resources/oauth-alpha.yml
@@ -34,4 +34,4 @@ spring:
 
 # 애플 key path 정보
 apple:
-  key-path: /key/private.p8
+  key-path: ~/key/private.p8

--- a/backend/src/main/resources/oauth-alpha.yml
+++ b/backend/src/main/resources/oauth-alpha.yml
@@ -12,9 +12,26 @@ spring:
             scope:
               - profile_nickname
               - account_email
+          apple:
+            client-id: sullogapp.sullog.com
+            redirect-uri: https://sullog-client.vercel.app/api/redirect/apple
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Apple
+            scope:
+              - account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize # 미사용
+            token-uri: https://appleid.apple.com/auth/token
+            user-info-uri: https://appleid.apple.com/auth/token
+            user-name-attribute: id
+
+# 애플 key path 정보
+apple:
+  key-path: /key/private.p8

--- a/backend/src/main/resources/oauth-live.yml
+++ b/backend/src/main/resources/oauth-live.yml
@@ -34,4 +34,4 @@ spring:
 
 # 애플 key path 정보
 apple:
-  key-path: /key/private.p8
+  key-path: ~/key/private.p8

--- a/backend/src/main/resources/oauth-live.yml
+++ b/backend/src/main/resources/oauth-live.yml
@@ -12,9 +12,26 @@ spring:
             scope:
               - profile_nickname
               - account_email
+          apple:
+            client-id: sullogapp.sullog.com
+            redirect-uri: https://sullog-client.vercel.app/api/redirect/apple
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Apple
+            scope:
+              - account_email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize # 미사용
+            token-uri: https://appleid.apple.com/auth/token
+            user-info-uri: https://appleid.apple.com/auth/token
+            user-name-attribute: id
+
+# 애플 key path 정보
+apple:
+  key-path: /key/private.p8

--- a/backend/src/main/resources/oauth-local.yml
+++ b/backend/src/main/resources/oauth-local.yml
@@ -12,9 +12,26 @@ spring:
             scope:
               - profile_nickname
               - account_email
+          apple:
+            client-id: sullogapp.sullog.com
+            redirect-uri: https://sullog-client.vercel.app/api/redirect/apple
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Apple
+            scope:
+              - account_email
         provider:
           kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            authorization-uri: https://kauth.kakao.com/oauth/authorize # 미사용
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize # 미사용
+            token-uri: https://appleid.apple.com/auth/token
+            user-info-uri: https://appleid.apple.com/auth/token
+            user-name-attribute: id
+
+# 애플 key path 정보
+apple:
+  key-path: /key/private.p8

--- a/backend/src/main/resources/static/docs/api-doc.html
+++ b/backend/src/main/resources/static/docs/api-doc.html
@@ -454,6 +454,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_1_사용자">1. 사용자</a>
 <ul class="sectlevel2">
 <li><a href="#_카카오_로그인_요청">카카오 로그인 요청</a></li>
+<li><a href="#_애플_로그인_요청">애플 로그인 요청</a></li>
 <li><a href="#_jwt_토큰_리프레시">jwt 토큰 리프레시</a></li>
 <li><a href="#_최근_검색어_조회">최근 검색어 조회</a></li>
 <li><a href="#_최근_검색어_중_특정_검색어_제거">최근 검색어 중 특정 검색어 제거</a></li>
@@ -664,16 +665,53 @@ Refresh: sample_refresh_token</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_jwt_토큰_리프레시">jwt 토큰 리프레시</h3>
+<h3 id="_애플_로그인_요청">애플 로그인 요청</h3>
+<div class="paragraph">
+<p>클라이언트에서 인가코드와 유저 정보를 넘겨주면, 인가코드 기반으로 유저정보를 검증하고 jwt토큰 반환</p>
+</div>
 <div class="sect3">
 <h4 id="_request_2">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /token/refresh HTTP/1.1
-Authorization: sample_token
-Host: localhost:8080</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /apple HTTP/1.1
+Content-Type: application/json
+Content-Length: 89
+Host: localhost:8080
+
+{"code":"test_code","name":"애플 계정에 등록된 이름","email":"apple@email.com"}</code></pre>
 </div>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">애플 인증 서버에서 발급해준 인가코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">애플 인증 서버에서 넘겨준 user 필드의 name 값(LastName+FirstName)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">애플 인증 서버에서 넘겨준 user 필드의 email 값</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_response_2">Response</h4>
@@ -709,9 +747,54 @@ Refresh: sample_refresh_token</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_최근_검색어_조회">최근 검색어 조회</h3>
+<h3 id="_jwt_토큰_리프레시">jwt 토큰 리프레시</h3>
 <div class="sect3">
 <h4 id="_request_3">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /token/refresh HTTP/1.1
+Authorization: sample_token
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_3">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Authorization: sample_access_token
+Refresh: sample_refresh_token</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The new access token</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Refresh</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The new refresh token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_최근_검색어_조회">최근 검색어 조회</h3>
+<div class="sect3">
+<h4 id="_request_4">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/me/recent-search-history HTTP/1.1
@@ -740,7 +823,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_3">Response</h4>
+<h4 id="_response_4">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -757,7 +840,7 @@ Content-Length: 53
 <div class="sect2">
 <h3 id="_최근_검색어_중_특정_검색어_제거">최근 검색어 중 특정 검색어 제거</h3>
 <div class="sect3">
-<h4 id="_request_4">Request</h4>
+<h4 id="_request_5">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me/recent-search-history/abc HTTP/1.1
@@ -805,7 +888,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_4">Response</h4>
+<h4 id="_response_5">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
@@ -816,56 +899,13 @@ Host: localhost:8080</code></pre>
 <div class="sect2">
 <h3 id="_최근_검색어_목록_초기화">최근 검색어 목록 초기화</h3>
 <div class="sect3">
-<h4 id="_request_5">Request</h4>
+<h4 id="_request_6">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me/recent-search-history HTTP/1.1
 Content-Type: application/json
 Authorization: sample_token
 Host: localhost:8080</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자의 access token</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_response_5">Response</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_최근_검색어_단건_저장">최근 검색어 단건 저장</h3>
-<div class="sect3">
-<h4 id="_request_6">Request</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/me/recent-search-history HTTP/1.1
-Content-Type: application/json
-Content-Length: 40
-Authorization: Bearer accessToken
-Host: localhost:8080
-
-{"keyword":"최근 검색어 키워드"}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -897,14 +937,18 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect2">
-<h3 id="_회원_탈퇴">회원 탈퇴</h3>
+<h3 id="_최근_검색어_단건_저장">최근 검색어 단건 저장</h3>
 <div class="sect3">
 <h4 id="_request_7">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me HTTP/1.1
-Authorization: sample_token
-Host: localhost:8080</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/me/recent-search-history HTTP/1.1
+Content-Type: application/json
+Content-Length: 40
+Authorization: Bearer accessToken
+Host: localhost:8080
+
+{"keyword":"최근 검색어 키워드"}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -935,6 +979,45 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_회원_탈퇴">회원 탈퇴</h3>
+<div class="sect3">
+<h4 id="_request_8">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me HTTP/1.1
+Authorization: sample_token
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자의 access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_8">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -943,7 +1026,7 @@ Host: localhost:8080</code></pre>
 <div class="sect2">
 <h3 id="_키워드_기반_전통주_검색">키워드 기반 전통주 검색</h3>
 <div class="sect3">
-<h4 id="_request_8">Request</h4>
+<h4 id="_request_9">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /alcohols/search?keyword=keyword&amp;cursor=1&amp;limit=1 HTTP/1.1
@@ -979,7 +1062,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_8">Response</h4>
+<h4 id="_response_9">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1020,7 +1103,7 @@ Content-Length: 681
 <div class="sect2">
 <h3 id="_전통주_id기반_전통주_단건_조회">전통주 id기반 전통주 단건 조회</h3>
 <div class="sect3">
-<h4 id="_request_9">Request</h4>
+<h4 id="_request_10">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /alcohols?alcoholId=1 HTTP/1.1
@@ -1048,7 +1131,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_9">Response</h4>
+<h4 id="_response_10">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1078,7 +1161,7 @@ Content-Length: 272
 <div class="sect2">
 <h3 id="_전통주_경험_저장">전통주 경험 저장</h3>
 <div class="sect3">
-<h4 id="_request_10">Request</h4>
+<h4 id="_request_11">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /records HTTP/1.1
@@ -1100,7 +1183,7 @@ test2
 Content-Disposition: form-data; name=recordInfo
 Content-Type: application/json
 
-{"alcoholId":1,"alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"starScore":5.0,"scentScore":3.0,"tasteScore":4.0,"textureScore":5.0,"description":"This is a test record.","experienceDate":"2023-07-30"}
+{"alcoholId":1,"alcoholPercentFeeling":"STRONG","flavorTagList":[{"majorTag":"FLOWER","detailTag":"CHRYSANTHEMUM"},{"majorTag":"DAIRY","detailTag":"BUTTER"}],"starScore":5.0,"scentScore":3.0,"tasteScore":4.0,"textureScore":5.0,"description":"This is a test record.","experienceDate":"2023-08-28"}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
@@ -1199,7 +1282,7 @@ Content-Type: application/json
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_10">Response</h4>
+<h4 id="_response_11">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
@@ -1256,7 +1339,7 @@ Content-Length: 20
 <div class="sect2">
 <h3 id="_특정_사용자의_전통주_경험_조회">특정 사용자의 전통주 경험 조회</h3>
 <div class="sect3">
-<h4 id="_request_11">Request</h4>
+<h4 id="_request_12">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me HTTP/1.1
@@ -1266,7 +1349,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_11">Response</h4>
+<h4 id="_response_12">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1380,7 +1463,7 @@ Content-Length: 1062
 <div class="sect2">
 <h3 id="_경험기록_id_기반_전통주_경험_단건_조회">경험기록 id 기반 전통주 경험 단건 조회</h3>
 <div class="sect3">
-<h4 id="_request_12">Request</h4>
+<h4 id="_request_13">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/1 HTTP/1.1
@@ -1408,7 +1491,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_12">Response</h4>
+<h4 id="_response_13">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1596,7 +1679,7 @@ Content-Length: 849
 <div class="sect2">
 <h3 id="_특정_사용자의_키워드_기반_경험기록_검색">특정 사용자의 키워드 기반 경험기록 검색</h3>
 <div class="sect3">
-<h4 id="_request_13">Request</h4>
+<h4 id="_request_14">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me/search?cursor=1&amp;keyword=keyword&amp;limit=2 HTTP/1.1
@@ -1632,7 +1715,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_13">Response</h4>
+<h4 id="_response_14">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1761,7 +1844,7 @@ Content-Length: 834
 <div class="sect2">
 <h3 id="_경험_피드">경험 피드</h3>
 <div class="sect3">
-<h4 id="_request_14">Request</h4>
+<h4 id="_request_15">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records?cursor=1&amp;limit=2 HTTP/1.1
@@ -1793,7 +1876,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_14">Response</h4>
+<h4 id="_response_15">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1929,7 +2012,7 @@ Content-Length: 880
 <div class="sect2">
 <h3 id="_사용자_경험_통계">사용자 경험 통계</h3>
 <div class="sect3">
-<h4 id="_request_15">Request</h4>
+<h4 id="_request_16">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me/statistics HTTP/1.1
@@ -1939,7 +2022,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_15">Response</h4>
+<h4 id="_response_16">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -2305,7 +2388,7 @@ Content-Length: 172
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-07-30 12:48:42 +0900
+Last updated 2023-08-28 00:43:15 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/main/resources/static/docs/api-doc.html
+++ b/backend/src/main/resources/static/docs/api-doc.html
@@ -454,7 +454,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_1_사용자">1. 사용자</a>
 <ul class="sectlevel2">
 <li><a href="#_카카오_로그인_요청">카카오 로그인 요청</a></li>
-<li><a href="#_애플_로그인_요청">애플 로그인 요청</a></li>
+<li><a href="#_애플_로그인_요청최초_가입">애플 로그인 요청(최초 가입)</a></li>
+<li><a href="#_애플_로그인_요청로그인_풀려서_로그인">애플 로그인 요청(로그인 풀려서 로그인)</a></li>
 <li><a href="#_jwt_토큰_리프레시">jwt 토큰 리프레시</a></li>
 <li><a href="#_최근_검색어_조회">최근 검색어 조회</a></li>
 <li><a href="#_최근_검색어_중_특정_검색어_제거">최근 검색어 중 특정 검색어 제거</a></li>
@@ -665,7 +666,7 @@ Refresh: sample_refresh_token</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_애플_로그인_요청">애플 로그인 요청</h3>
+<h3 id="_애플_로그인_요청최초_가입">애플 로그인 요청(최초 가입)</h3>
 <div class="paragraph">
 <p>클라이언트에서 인가코드와 유저 정보를 넘겨주면, 인가코드 기반으로 유저정보를 검증하고 jwt토큰 반환</p>
 </div>
@@ -747,16 +748,43 @@ Refresh: sample_refresh_token</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_jwt_토큰_리프레시">jwt 토큰 리프레시</h3>
+<h3 id="_애플_로그인_요청로그인_풀려서_로그인">애플 로그인 요청(로그인 풀려서 로그인)</h3>
+<div class="paragraph">
+<p>클라이언트에서 인가코드를 넘겨주면, 인가코드 기반으로 유저정보를 조회해서 jwt토큰 반환</p>
+</div>
 <div class="sect3">
 <h4 id="_request_3">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /token/refresh HTTP/1.1
-Authorization: sample_token
-Host: localhost:8080</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /apple HTTP/1.1
+Content-Type: application/json
+Content-Length: 20
+Host: localhost:8080
+
+{"code":"test_code"}</code></pre>
 </div>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">애플 인증 서버에서 발급해준 인가코드</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_response_3">Response</h4>
@@ -792,9 +820,54 @@ Refresh: sample_refresh_token</code></pre>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_최근_검색어_조회">최근 검색어 조회</h3>
+<h3 id="_jwt_토큰_리프레시">jwt 토큰 리프레시</h3>
 <div class="sect3">
 <h4 id="_request_4">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /token/refresh HTTP/1.1
+Authorization: sample_token
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_4">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Authorization: sample_access_token
+Refresh: sample_refresh_token</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The new access token</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Refresh</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The new refresh token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_최근_검색어_조회">최근 검색어 조회</h3>
+<div class="sect3">
+<h4 id="_request_5">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /members/me/recent-search-history HTTP/1.1
@@ -823,7 +896,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_4">Response</h4>
+<h4 id="_response_5">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -840,7 +913,7 @@ Content-Length: 53
 <div class="sect2">
 <h3 id="_최근_검색어_중_특정_검색어_제거">최근 검색어 중 특정 검색어 제거</h3>
 <div class="sect3">
-<h4 id="_request_5">Request</h4>
+<h4 id="_request_6">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me/recent-search-history/abc HTTP/1.1
@@ -888,7 +961,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_5">Response</h4>
+<h4 id="_response_6">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
@@ -899,56 +972,13 @@ Host: localhost:8080</code></pre>
 <div class="sect2">
 <h3 id="_최근_검색어_목록_초기화">최근 검색어 목록 초기화</h3>
 <div class="sect3">
-<h4 id="_request_6">Request</h4>
+<h4 id="_request_7">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me/recent-search-history HTTP/1.1
 Content-Type: application/json
 Authorization: sample_token
 Host: localhost:8080</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사용자의 access token</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_response_6">Response</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_최근_검색어_단건_저장">최근 검색어 단건 저장</h3>
-<div class="sect3">
-<h4 id="_request_7">Request</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/me/recent-search-history HTTP/1.1
-Content-Type: application/json
-Content-Length: 40
-Authorization: Bearer accessToken
-Host: localhost:8080
-
-{"keyword":"최근 검색어 키워드"}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -980,14 +1010,18 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect2">
-<h3 id="_회원_탈퇴">회원 탈퇴</h3>
+<h3 id="_최근_검색어_단건_저장">최근 검색어 단건 저장</h3>
 <div class="sect3">
 <h4 id="_request_8">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me HTTP/1.1
-Authorization: sample_token
-Host: localhost:8080</code></pre>
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /members/me/recent-search-history HTTP/1.1
+Content-Type: application/json
+Content-Length: 40
+Authorization: Bearer accessToken
+Host: localhost:8080
+
+{"keyword":"최근 검색어 키워드"}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1018,6 +1052,45 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_회원_탈퇴">회원 탈퇴</h3>
+<div class="sect3">
+<h4 id="_request_9">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /members/me HTTP/1.1
+Authorization: sample_token
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자의 access token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_9">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1026,7 +1099,7 @@ Host: localhost:8080</code></pre>
 <div class="sect2">
 <h3 id="_키워드_기반_전통주_검색">키워드 기반 전통주 검색</h3>
 <div class="sect3">
-<h4 id="_request_9">Request</h4>
+<h4 id="_request_10">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /alcohols/search?keyword=keyword&amp;cursor=1&amp;limit=1 HTTP/1.1
@@ -1062,7 +1135,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_9">Response</h4>
+<h4 id="_response_10">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1103,7 +1176,7 @@ Content-Length: 681
 <div class="sect2">
 <h3 id="_전통주_id기반_전통주_단건_조회">전통주 id기반 전통주 단건 조회</h3>
 <div class="sect3">
-<h4 id="_request_10">Request</h4>
+<h4 id="_request_11">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /alcohols?alcoholId=1 HTTP/1.1
@@ -1131,7 +1204,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_10">Response</h4>
+<h4 id="_response_11">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1161,7 +1234,7 @@ Content-Length: 272
 <div class="sect2">
 <h3 id="_전통주_경험_저장">전통주 경험 저장</h3>
 <div class="sect3">
-<h4 id="_request_11">Request</h4>
+<h4 id="_request_12">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /records HTTP/1.1
@@ -1282,7 +1355,7 @@ Content-Type: application/json
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_11">Response</h4>
+<h4 id="_response_12">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
@@ -1339,7 +1412,7 @@ Content-Length: 20
 <div class="sect2">
 <h3 id="_특정_사용자의_전통주_경험_조회">특정 사용자의 전통주 경험 조회</h3>
 <div class="sect3">
-<h4 id="_request_12">Request</h4>
+<h4 id="_request_13">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me HTTP/1.1
@@ -1349,7 +1422,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_12">Response</h4>
+<h4 id="_response_13">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1463,7 +1536,7 @@ Content-Length: 1062
 <div class="sect2">
 <h3 id="_경험기록_id_기반_전통주_경험_단건_조회">경험기록 id 기반 전통주 경험 단건 조회</h3>
 <div class="sect3">
-<h4 id="_request_13">Request</h4>
+<h4 id="_request_14">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/1 HTTP/1.1
@@ -1491,7 +1564,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_13">Response</h4>
+<h4 id="_response_14">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1679,7 +1752,7 @@ Content-Length: 849
 <div class="sect2">
 <h3 id="_특정_사용자의_키워드_기반_경험기록_검색">특정 사용자의 키워드 기반 경험기록 검색</h3>
 <div class="sect3">
-<h4 id="_request_14">Request</h4>
+<h4 id="_request_15">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me/search?cursor=1&amp;keyword=keyword&amp;limit=2 HTTP/1.1
@@ -1715,7 +1788,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_14">Response</h4>
+<h4 id="_response_15">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -1844,7 +1917,7 @@ Content-Length: 834
 <div class="sect2">
 <h3 id="_경험_피드">경험 피드</h3>
 <div class="sect3">
-<h4 id="_request_15">Request</h4>
+<h4 id="_request_16">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records?cursor=1&amp;limit=2 HTTP/1.1
@@ -1876,7 +1949,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_15">Response</h4>
+<h4 id="_response_16">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -2012,7 +2085,7 @@ Content-Length: 880
 <div class="sect2">
 <h3 id="_사용자_경험_통계">사용자 경험 통계</h3>
 <div class="sect3">
-<h4 id="_request_16">Request</h4>
+<h4 id="_request_17">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /records/me/statistics HTTP/1.1
@@ -2022,7 +2095,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_16">Response</h4>
+<h4 id="_response_17">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -2388,7 +2461,7 @@ Content-Length: 172
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-28 00:43:15 +0900
+Last updated 2023-08-28 01:27:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/backend/src/test/java/sullog/backend/member/controller/AuthControllerTest.java
+++ b/backend/src/test/java/sullog/backend/member/controller/AuthControllerTest.java
@@ -1,11 +1,13 @@
 package sullog.backend.member.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -14,6 +16,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import sullog.backend.auth.controller.AuthController;
+import sullog.backend.auth.dto.request.AppleLoginRequestDto;
+import sullog.backend.auth.service.AppleService;
 import sullog.backend.auth.service.KakaoService;
 import sullog.backend.member.config.jwt.JwtAuthFilter;
 import sullog.backend.member.entity.Member;
@@ -21,15 +25,20 @@ import sullog.backend.member.entity.Token;
 import sullog.backend.auth.service.TokenService;
 import sullog.backend.member.service.MemberService;
 
-import static org.mockito.ArgumentMatchers.anyInt;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AuthController.class)
@@ -48,7 +57,12 @@ class AuthControllerTest {
     private KakaoService kakaoService;
 
     @MockBean
+    private AppleService appleService;
+
+    @MockBean
     private MemberService memberService;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     public void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
@@ -85,7 +99,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void 인가코드를_전달받으면_jwt토큰을_반환한다() throws Exception {
+    void 인가코드를_전달받으면_jwt토큰을_반환한다_카카오로그인() throws Exception {
         // given
         String code = "test_code";
         String accessToken = "test_accessToken";
@@ -107,6 +121,47 @@ class AuthControllerTest {
                 .andDo(document("oauth2/request-kakao-login",
                         requestParameters( // path 파라미터 정보 입력
                                 parameterWithName("code").description("카카오 인증 서버에서 발급해준 인가코드")
+                        ),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("The new access token"), // response-headers.adoc 파일에 추가
+                                headerWithName("Refresh").description("The new refresh token") // response-headers.adoc 파일에 추가
+                        )
+                ));
+    }
+
+    @Test
+    void 인가코드를_전달받으면_jwt토큰을_반환한다_애플로그인() throws Exception {
+        // given
+        String code = "test_code";
+        Member member = Member.builder()
+                .nickName("애플 계정에 등록된 이름")
+                .email("apple@email.com")
+                .build();
+        Token newToken = new Token("sample_access_token", "sample_refresh_token");
+        AppleLoginRequestDto appleLoginRequestDto = AppleLoginRequestDto.builder()
+                .code(code)
+                .name(member.getNickName())
+                .email(member.getEmail())
+                .build();
+
+        when(appleService.verifyUserInfo(eq(code), any())).thenReturn(member);
+        when(memberService.findMemberByEmail(member.getEmail())).thenReturn(member);
+        when(tokenService.generateToken(member.getMemberId(), "USER")).thenReturn(newToken);
+
+        // when, then
+        this.mockMvc.perform(
+                        post("/apple")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(appleLoginRequestDto).getBytes(StandardCharsets.UTF_8)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.AUTHORIZATION, newToken.getAccessToken()))
+                .andExpect(MockMvcResultMatchers.header().string("Refresh", newToken.getRefreshToken()))
+                .andDo(document("oauth2/request-apple-login",
+                        requestFields(
+                                fieldWithPath("code").description("애플 인증 서버에서 발급해준 인가코드"),
+                                fieldWithPath("name").description("애플 인증 서버에서 넘겨준 user 필드의 name 값(LastName+FirstName)"),
+                                fieldWithPath("email").description("애플 인증 서버에서 넘겨준 user 필드의 email 값")
                         ),
                         responseHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("The new access token"), // response-headers.adoc 파일에 추가


### PR DESCRIPTION
## 개요
- #146 에 덧붙여서, 회원가입 이후 로그인 케이스 처리
### 차이점
최초 애플 로그인 시 - 인가 code + user데이터 넘겨줌
그 이후 로그인 - 인가 code만 넘겨줌

## 작업사항
- 인가 code만 넘어왔을 때, db에서 유저 조회 후 jwt 토큰 발급하도록 수정

## 변경로직
- requestdto의 name, email값을 nullabl하게 처리
  - null 임 -> 이미 회원가입된 상태이고, 재로그인 케이스임
  - null 아님 -> 최초 로그인(회원가입) 케이스임
- 인가코드로 email 조회 해서 jwt 토큰 발급해주도록 수정
- alpha, live 환경 private key 파일 path 변경 및 서버에서 설정
     - <img width="340" alt="image" src="https://github.com/sullog-official/sullog-server/assets/48347010/df8d3143-2c50-4f7e-940b-1f9e966be188">
