### PR TITLE
feat: 테스트용 슈퍼 유저 토큰 추가

### DIFF
--- a/backend/src/main/java/sullog/backend/auth/service/TokenService.java
+++ b/backend/src/main/java/sullog/backend/auth/service/TokenService.java
@@ -30,6 +30,15 @@ public class TokenService implements InitializingBean {
 
     private final MemberService memberService;
 
+    /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+    /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+    /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+    @Value("${super-user.user-token}")
+    private String TEST_USER_TOKEN;
+
+    @Value("${super-user.user-id}")
+    private String TEST_USER_ID;
+
     public TokenService(
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInMilliseconds,
@@ -75,6 +84,13 @@ public class TokenService implements InitializingBean {
             return false;
         }
 
+        /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+        /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+        /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+        if (token.equals(TEST_USER_TOKEN)) {
+            return true;
+        }
+
         String value = token.substring(BEARER_PREFIX.length());
 
         try {
@@ -99,6 +115,12 @@ public class TokenService implements InitializingBean {
     }
 
     public int getMemberId(String token) {
+        /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+        /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+        /** TODO 개발용 인증 토큰 발급이므로 추후 반드시 삭제해야함 */
+        if (token.equals(TEST_USER_TOKEN)) {
+            return Integer.parseInt(TEST_USER_ID);
+        }
         String value = token.substring(BEARER_PREFIX.length());
         String subject = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(value).getBody().getSubject();
         return Integer.parseInt(subject);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,3 +22,7 @@ allow-image-format: "jpg,JPG,jpeg,JPEG,png,PNG,heic,HEIC"
 apple:
   key-id: ENC(ORo6z0J1KSyBrKlYyVJ+yorUTL0w//tE)
   team-id: ENC(GTa1yuSegpc8cVuJpEGd6evUErK5Szsf)
+
+super-user:
+  user-token: ENC(mdf8JBymXo6wARDFPuqsYewfqEInQvFv11rC7i6ZK09n6iYLvH8rpCB+qEY9CE6X)
+  user-id: ENC(MfxXeRccwQPcBKSdRt7D7g==)


### PR DESCRIPTION
## 개요
- 프론트의 원활한 개발을 위한 테스트용 슈퍼 유저 토큰 추가

## 작업사항
- 특정 Bearer 토큰 값 입력 시 즉시 슈퍼 유저 정보를 리턴하도록 로직 수정
- 해당 토큰 값은 암호화 후 yml파일에 적재함
- 원본 값은 @cnpcnp99 에게 문의
